### PR TITLE
Deprecation text per 70127.

### DIFF
--- a/Azure AD Cmdlets/MSOnline/v1/AzureActiveDirectory.md
+++ b/Azure AD Cmdlets/MSOnline/v1/AzureActiveDirectory.md
@@ -349,7 +349,7 @@ Enables the multinational feature for a service type for a company with Azure Ac
 
 
 ### [Set-MsolCompanySecurityComplianceContactInformation](./Set-MsolCompanySecurityComplianceContactInformation.md)
-This cmdlet is not in use by any online service, so please consider it deprecated.  
+**This cmdlet is not in use by any online service, so please consider it deprecated.**  
 For more information about how to properly configure security contact details in Azure Security Center, see [Provide security contact details in Azure Security Center](https://aka.ms/azuresecuritycontact).
 
 Sets company-level security and compliance contact preferences.

--- a/Azure AD Cmdlets/MSOnline/v1/Set-MsolCompanySecurityComplianceContactInformation.md
+++ b/Azure AD Cmdlets/MSOnline/v1/Set-MsolCompanySecurityComplianceContactInformation.md
@@ -8,7 +8,8 @@ ms.assetid: 5EFA8894-F622-48D0-97D4-3D673E08FF37
 # Set-MsolCompanySecurityComplianceContactInformation
 
 ## SYNOPSIS
-Sets company-level security and compliance contact preferences.
+**This cmdlet is not in use by any online service, so please consider it deprecated.**  
+
 
 ## SYNTAX
 
@@ -18,7 +19,7 @@ Set-MsolCompanySecurityComplianceContactInformation [-SecurityComplianceNotifica
 ```
 
 ## DESCRIPTION
-This cmdlet is not in use by any online service, so please consider it deprecated.  
+**This cmdlet is not in use by any online service, so please consider it deprecated.**  
 For more information about how to properly configure security contact details in Azure Security Center, see [Provide security contact details in Azure Security Center](https://aka.ms/azuresecuritycontact).
 
 The **Set-MsolCompanySecurityComplianceContactInformation** cmdlet sets company-level security and compliance contact preferences.
@@ -32,6 +33,8 @@ The contact is used for notification purposes.
 ```
 Set-MsolCompanySecurityComplianceContactInformation -SecurityComplianceNotificationEmails "EvanNarvaez@contoso.com", "ElisaDaugherty@contoso.com" -SecuritComplianceNotificationPhones "555-555-0012","555-555-0199"
 ```
+**This cmdlet is not in use by any online service, so please consider it deprecated.**  
+For more information about how to properly configure security contact details in Azure Security Center, see [Provide security contact details in Azure Security Center](https://aka.ms/azuresecuritycontact).
 
 This command sets multiple email addresses as company-level security and compliance contacts and respective phone numbers for each contact.
 
@@ -40,6 +43,9 @@ This command sets multiple email addresses as company-level security and complia
 
 ### -SecurityComplianceNotificationEmails
 Specifies an array of company-level security and compliance contact email addresses.
+
+**This cmdlet is not in use by any online service, so please consider it deprecated.**  
+For more information about how to properly configure security contact details in Azure Security Center, see [Provide security contact details in Azure Security Center](https://aka.ms/azuresecuritycontact).
 
 ```yaml
 Type: String[]
@@ -55,6 +61,9 @@ Accept wildcard characters: False
 
 ### -SecurityComplianceNotificationPhones
 Specifies an array of company-level security and compliance contact phone numbers.
+
+**This cmdlet is not in use by any online service, so please consider it deprecated.**  
+For more information about how to properly configure security contact details in Azure Security Center, see [Provide security contact details in Azure Security Center](https://aka.ms/azuresecuritycontact).
 
 ```yaml
 Type: String[]
@@ -72,6 +81,9 @@ Accept wildcard characters: False
 Specifies the unique ID of the tenant on which to perform the operation.
 The default value is the tenant of the current user.
 This parameter applies only to partner users.
+
+**This cmdlet is not in use by any online service, so please consider it deprecated.**  
+For more information about how to properly configure security contact details in Azure Security Center, see [Provide security contact details in Azure Security Center](https://aka.ms/azuresecuritycontact).
 
 
 ```yaml
@@ -99,5 +111,7 @@ System.Nullable`1[[System.Guid, mscorlib, Version=4.0.0.0, Culture=neutral, Publ
 ### System.Object
 
 ## NOTES
+**This cmdlet is not in use by any online service, so please consider it deprecated.**  
+For more information about how to properly configure security contact details in Azure Security Center, see [Provide security contact details in Azure Security Center](https://aka.ms/azuresecuritycontact).
 
 ## RELATED LINKS


### PR DESCRIPTION
PG wanted the deprecation info to appear throughout the file. This involved bending some of our writing rules. I did leave the original text, in addition to the deprecation text. MS policy is to document deprecated features for backward compatibility. 