### PR TITLE
Overhaul user and group app role assignment cmdlets

### DIFF
--- a/Azure AD Cmdlets/AzureAD/v2/New-AzureADGroupAppRoleAssignment.md
+++ b/Azure AD Cmdlets/AzureAD/v2/New-AzureADGroupAppRoleAssignment.md
@@ -10,24 +10,121 @@ ms.custom: iamfeature=PowerShell
 # New-AzureADGroupAppRoleAssignment
 
 ## SYNOPSIS
-Assign a group of users to an application role.
+Assigns a group to an application role.
 
 ## SYNTAX
 
 ```
-New-AzureADGroupAppRoleAssignment -ObjectId <String> [-InformationAction <ActionPreference>]
- [-InformationVariable <String>] -Id <String> -PrincipalId <String> -ResourceId <String> [<CommonParameters>]
+New-AzureADGroupAppRoleAssignment -ObjectId <String> -PrincipalId <String> -ResourceId <String> -Id <String>
+[-InformationAction <ActionPreference>] [-InformationVariable <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The **New-AzureADGroupAppRoleAssignment** cmdlet assigns a group of users to an application role in Azure Active Directory (AD).
+The **New-AzureADGroupAppRoleAssignment** cmdlet assigns a group to an application role in Azure Active Directory (AD).
 
 ## EXAMPLES
 
+### Example 1: Assign a group to an application without roles
+
+This example assigns a group to an application that doesn't have any app roles defined, using the default app role ID.
+
+```PowerShell
+# Get the service principal of the app to assign the group to
+$servicePrincipal = Get-AzureADServicePrincipal -SearchString "<Your app's display name>"
+
+# Get the group to be assigned
+$group = Get-AzureADGroup -SearchString "<Your group's name>"
+
+# Create the group app role assignment
+New-AzureADGroupAppRoleAssignment -ObjectId $group.ObjectId -PrincipalId $group.ObjectId -ResourceId $servicePrincipal.ObjectId -Id ([Guid]::Empty)
+```
+
+### Example 2: Assign a group to a specific app role within an application
+
+This example assigns the specified group to a given app role. Please refer to the description of the `-Id` parameter for more information on how to retrieve application roles for an application.
+
+```PowerShell
+$group_name = "<You group's name>"
+$app_name = "<Your App's display name>"
+$app_role_name = "<App role display name>"
+
+# Get the group to assign, and the service principal for the app to assign to
+$group = Get-AzureADGroup -SearchString "$group_name"
+$sp = Get-AzureADServicePrincipal -Filter "displayName eq '$app_name'"
+$appRole = $sp.AppRoles | Where-Object { $_.DisplayName -eq $app_role_name }
+
+# Assign the group to the app role
+New-AzureADGroupAppRoleAssignment -ObjectId $group.ObjectId -PrincipalId $group.ObjectId -ResourceId $sp.ObjectId -Id $appRole.Id
+```
+
 ## PARAMETERS
 
+### -ObjectId
+The object ID of the group in Azure AD to be assigned to the app role.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -PrincipalId
+The object ID of the principal which will be assigned to the app role. When assigning a group to an app role, provide the object ID of the group.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ResourceId
+The object ID of the ServicePrincipal for the application for which the group is being assigned an app role.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 ### -Id
-Specifies the ID.
+The ID of the app role to assign. Provide an empty Guid (`[Guid]::Empty`) when creating an app role assignement for an application that does not have any app roles defined, or the `Id` of the app role to assign the group to.
+
+You can retrieve the application's app roles by examining the application object's AppRoles property:
+
+```Powershell
+Get-AzureADServicePrincipal -SearchString "Your Application display name" | Format-List AppRoles 
+```
+
+This cmdlet returns the list of roles that are defined in an application:
+
+```
+AppRoles : {class AppRole {
+            AllowedMemberTypes: System.Collections.Generic.List1[System.String]
+            Description: <description for this role>
+            DisplayName: <display name for this role>
+            Id: 97e244a2-6ccd-4312-9de6-ecb21884c9f7
+            IsEnabled: True
+            Value: <Value that will be transmitted as a claim in a token for this role>
+        }
+        }
+```
 
 ```yaml
 Type: String
@@ -42,9 +139,7 @@ Accept wildcard characters: False
 ```
 
 ### -InformationAction
-Specifies how this cmdlet responds to an information event.
-
-The acceptable values for this parameter are:
+Specifies how this cmdlet responds to an information event. The acceptable values for this parameter are:
 
 - Continue
 - Ignore
@@ -80,51 +175,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -ObjectId
-Specifies the ID of a user (as a UPN or ObjectId) in Azure AD.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: 
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: True (ByPropertyName, ByValue)
-Accept wildcard characters: False
-```
-
-### -PrincipalId
-Specifies the principal ID.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: 
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ResourceId
-Specifies the resource ID.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: 
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
@@ -140,4 +190,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [Remove-AzureADGroupAppRoleAssignment](./Remove-AzureADGroupAppRoleAssignment.md)
 
-[Managing applications in Azure Active Directory using PowerShell](https://channel9.msdn.com/Series/Azure-Active-Directory-Videos-Demos/ManageAppsAzureADPowerShell) 

--- a/Azure AD Cmdlets/AzureAD/v2/New-AzureADUserAppRoleAssignment.md
+++ b/Azure AD Cmdlets/AzureAD/v2/New-AzureADUserAppRoleAssignment.md
@@ -15,8 +15,8 @@ Assigns a user to an application role.
 ## SYNTAX
 
 ```
-New-AzureADUserAppRoleAssignment -ObjectId <String> [-InformationAction <ActionPreference>]
- [-InformationVariable <String>] -Id <String> -PrincipalId <String> -ResourceId <String> [<CommonParameters>]
+New-AzureADUserAppRoleAssignment -ObjectId <String> -PrincipalId <String> -ResourceId <String> -Id <String>
+[-InformationAction <ActionPreference>] [-InformationVariable <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -25,58 +25,109 @@ The **New-AzureADUserAppRoleAssignment** cmdlet assigns a user to an application
 ## EXAMPLES
 
 ### Example 1: Assign a user to an application without roles
+
+This example assigns a user to an application that doesn't have any app roles defined, using the default app role ID.
+
 ```
-# Get AppId of the app to assign the user to
+# Get the service principal of the app to assign the user to
+$servicePrincipal = Get-AzureADServicePrincipal -SearchString "<Your app's display name>"
 
-$appId = Get-AzureADApplication -SearchString "<Your App's display name>"
-
-# Get the user to be added
-
+# Get the user to be assigned
 $user = Get-AzureADUser -searchstring "<Your user's UPN>"
 
-# Get the service principal for the app you want to assign the user to
-
-$servicePrincipal = Get-AzureADServicePrincipal -Filter "appId eq 'appId'"
-
 # Create the user app role assignment
-
 New-AzureADUserAppRoleAssignment -ObjectId $user.ObjectId -PrincipalId $user.ObjectId -ResourceId $servicePrincipal.ObjectId -Id ([Guid]::Empty)
 ```
 
-This command assigns a user to and application that doesn;t have any roles.
+### Example 2: Assign a user to a specific app role within an application
 
-### Example 2: Assign a user to a specific role within an application
-```
+This example assigns the specified user the to a given app role. Please refer to the description of the `-Id` parameter for more information on how to retrieve application roles for an application.
+
+```PowerShell
 $username = "<You user's UPN>"
-$appname = "<Your App's display name>"
-$spo = Get-AzureADServicePrincipal -Filter "Displayname eq '$appname'"
-$user = Get-AzureADUser -ObjectId $username
-New-AzureADUserAppRoleAssignment -ObjectId $user.ObjectId -PrincipalId $user.ObjectId -ResourceId $spo.ObjectId -Id $spo.Approles[1].id
+$app_name = "<Your App's display name>"
+$app_role_name = "<App role display name>"
+
+# Get the user to assign, and the service principal for the app to assign to
+$user = Get-AzureADUser -ObjectId "$username"
+$sp = Get-AzureADServicePrincipal -Filter "displayName eq '$app_name'"
+$appRole = $sp.AppRoles | Where-Object { $_.DisplayName -eq $app_role_name }
+
+#Assign the user to the app role
+New-AzureADUserAppRoleAssignment -ObjectId $user.ObjectId -PrincipalId $user.ObjectId -ResourceId $sp.ObjectId -Id $appRole.Id
 ```
 
-This cmdlet assigns to the specified user the application role of which the Id is specified with $spo.Approles[1].id. please refer to the description of the -Id parameter for more information on how to retrieve application roles for an application.
 
 ## PARAMETERS
 
+### -ObjectId
+The ID of the user (as a `UserPrincipalName` or `ObjectId`) in Azure AD to be assigned to the app role.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+
+### -PrincipalId
+The object ID of the principal to which the new app role is assigned. When assigning a user to an app role, provide the object ID of the user.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ResourceId
+The object ID of the ServicePrincipal for the application for which the user is being assigned an app role.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: 
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Id
-The ID of the app role to assign. Provide an empty guid when creating a new app role assignement for an application that does not have any roles, or the Id of the role to assign to the user.
+The ID of the app role to assign. Provide an empty Guid (`[Guid]::Empty`) when creating an app role assignement for an application that does not have any app roles defined, or the `Id` of the app role to assign the user to.
 
-You can retrieve the application's roles by examining the application object's AppRoles property:
+You can retrieve the application's app roles by examining the application object's AppRoles property:
 
-	Get-AzureadApplication -SearchString "Your Application display name" | select Approles | Fl 
+```Powershell
+Get-AzureADServicePrincipal -SearchString "Your Application display name" | Format-List AppRoles 
+```
 
 This cmdlet returns the list of roles that are defined in an application:
 
-	AppRoles : {class AppRole {
-             AllowedMemberTypes: System.Collections.Generic.List1[System.String]
-             Description: <description for this role>
-             DisplayName: <display name for this role>
-             Id: 97e244a2-6ccd-4312-9de6-ecb21884c9f7
-             IsEnabled: True
-             Value: <Value that will be transmitted as a claim in a token for this role>
-           }
-           }
-
+```
+AppRoles : {class AppRole {
+            AllowedMemberTypes: System.Collections.Generic.List1[System.String]
+            Description: <description for this role>
+            DisplayName: <display name for this role>
+            Id: 97e244a2-6ccd-4312-9de6-ecb21884c9f7
+            IsEnabled: True
+            Value: <Value that will be transmitted as a claim in a token for this role>
+        }
+        }
+```
 
 ```yaml
 Type: String
@@ -121,51 +172,6 @@ Parameter Sets: (All)
 Aliases: iv
 
 Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ObjectId
-Specifies the ID of the user (as a UPN or ObjectId) in Azure AD to which the new app role is to be assigned
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: 
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: True (ByPropertyName, ByValue)
-Accept wildcard characters: False
-```
-
-### -PrincipalId
-The object ID of the principal to which the new app role is assigned. When assigning a new role to a user provide the object ID of the user.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: 
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ResourceId
-The object ID of the Service Principal for the application to which the user role is assigned.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases: 
-
-Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False


### PR DESCRIPTION
Changes parameter ordering to a logical order, fixes examples for `New-AzureADUserAppRoleAssignemnt`, adds equivalent examples for `New-AzureADGroupAppRoleAssignment`.