### PR TITLE
Added example of OAuth and SAML use cases

### DIFF
--- a/azureadps-2.0/AzureAD/New-AzureADApplication.md
+++ b/azureadps-2.0/AzureAD/New-AzureADApplication.md
@@ -48,6 +48,33 @@ acd10942-5747-4385-8824-4c5d5fa904f9 b5fecfab-0ea2-4fd1-8570-b2c41b3d5149 My new
 
 This command creates an application in Azure AD.
 
+### Example 2: Create an SAML application
+```
+PS C:\>New-AzureADApplication -DisplayName "My new SAML application"  -IdentifierUris "http://mynewapp.contoso.com" -SamlMetadataURL "http://mynewapp.contoso.com/metadata.xml" -ReplyUrls "http://mynewapp.contoso.com/finishLogin"
+
+ObjectId                             AppId                                DisplayName 
+--------                             -----                                ----------- 
+acd10942-5747-4385-8824-4c5d5fa904f9 b5fecfab-0ea2-4fd1-8570-b2c41b3d5149 My new application
+```
+
+This command creates an application in Azure AD with your SAML metadata.
+
+After this you still need to set permissions on who can access the application. 
+
+### Example 3: Create an OAuth application
+```
+PS C:\>New-AzureADApplication -DisplayName "My new SAML application"  -IdentifierUris "http://mynewapp.contoso.com" -ReplyUrls "http://mynewapp.contoso.com/oauth2/callback"
+
+ObjectId                             AppId                                DisplayName 
+--------                             -----                                ----------- 
+acd10942-5747-4385-8824-4c5d5fa904f9 b5fecfab-0ea2-4fd1-8570-b2c41b3d5149 My new application
+```
+
+This command creates an application in Azure AD prepped for OAuth.
+
+After this you still need to create the keys for your application and setup the permissions of the application. 
+
+
 ## PARAMETERS
 
 ### -AddIns


### PR DESCRIPTION
Documentation only had 1 example which showed how to create application, which isn't really useful when doing production deployments. 

It's much better to have example of SAML and OAuth setups where you set the replyURL to the application and if doing SAML based you add the SAML metadata which allows authentication immediately after you set the application login permissions. Which can't be set from this command unless you have the role setup. So its better to type that in its own tutorial. 

You could add the -GroupMembershipClaims to the example to allow groups, but as the groups are UUID I don't recommend having access to the groups.