### PR TITLE
Update New-AzureAdApplication.md

### DIFF
--- a/azureadps-2.0-preview/AzureAD/New-AzureADApplication.md
+++ b/azureadps-2.0-preview/AzureAD/New-AzureADApplication.md
@@ -166,7 +166,7 @@ Type: System.Collections.Generic.List`1[System.String]
 Parameter Sets: (All)
 Aliases: 
 
-Required: False
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False


### PR DESCRIPTION
Get-Help of the PowerShell command displays IdentifierUris Required as false - whereas the docs page displays it as a required parameter. Upon testing the field is indeed required to create a new application through PowerShell.