### PR TITLE
Update Get-AzureADApplicationPasswordCredential.md

### DIFF
--- a/azureadps-2.0/AzureAD/Get-AzureADApplicationPasswordCredential.md
+++ b/azureadps-2.0/AzureAD/Get-AzureADApplicationPasswordCredential.md
@@ -26,7 +26,7 @@ The **Get-AzureADApplicationPasswordCredential** cmdlet gets the password creden
 
 ### Example 1:
 ```
-PS C:\>New-AzureADApplicationPasswordCredential -ObjectId 3ddd22e7-a150-4bb3-b100-e410dea1cb84
+PS C:\>Get-AzureADApplicationPasswordCredential -ObjectId 3ddd22e7-a150-4bb3-b100-e410dea1cb84
 
 CustomKeyIdentifier :
 EndDate             : 9/28/2017 3:57:10 PM


### PR DESCRIPTION
Current Example section lists the command for creation of a new Password instead of the correct command
This is basically a typo correction