### PR TITLE
Update UsersPermissionToReadOtherUsersEnabled

### DIFF
--- a/azureadps-1.0/MSOnline/Set-MsolCompanySettings.md
+++ b/azureadps-1.0/MSOnline/Set-MsolCompanySettings.md
@@ -125,7 +125,7 @@ Accept wildcard characters: False
 ### -UsersPermissionToReadOtherUsersEnabled
 Indicates whether to allow users to view the profile info of other users in their company.
 This setting is applied company-wide.
-Set to $False to disable users' ability to use the Azure AD module for Windows PowerShell to access user information for their organization.
+Set to $False to disable users' ability to access user information for their organization.
 
 ```yaml
 Type: Boolean


### PR DESCRIPTION
Update the UsersPermissionToReadOtherUsersEnabled documentation to reflect the fact that the scope of this setting is not limited to the Powershell script.  This setting restricts user's ability to query for user information in other contexts as well (such as querying the user info from AAD web endpoints).