### PR TITLE
Update Get-AzureADUser.md

### DIFF
--- a/azureadps-2.0/AzureAD/Get-AzureADUser.md
+++ b/azureadps-2.0/AzureAD/Get-AzureADUser.md
@@ -69,7 +69,7 @@ This command gets the specified user.
 
 ### Example 5: Get a user by userPrincipalName
 ```
-PS C:\>Get-AzureADUser -Filter "startswith(Title,'Sales')"
+PS C:\>Get-AzureADUser -Filter "startswith(jobTitle,'Sales')"
 ```
 
 This command gets all the users whos title starts with sales. ie Sales Manager and Sales Assistant.


### PR DESCRIPTION
Example five uses the wrong property name of 'Title.' In AzureAD, the property is 'JobTitle.' Allthough, interestingly enough, 'jobTitle' must start with a lower case 'j' and not a capital 'J' as is returned by a successful query.