### PR TITLE
Update MailNickname and UserPrincipalName to required, per GraphAPI. Add Federated Example

### DIFF
--- a/azureadps-2.0/AzureAD/New-AzureADUser.md
+++ b/azureadps-2.0/AzureAD/New-AzureADUser.md
@@ -24,7 +24,7 @@ New-AzureADUser [-ExtensionProperty <System.Collections.Generic.Dictionary`2[Sys
  [-PreferredLanguage <String>] [-ShowInAddressList <Boolean>]
  [-SignInNames <System.Collections.Generic.List`1[Microsoft.Open.AzureAD.Model.SignInName]>] [-State <String>]
  [-StreetAddress <String>] [-Surname <String>] [-TelephoneNumber <String>] [-UsageLocation <String>]
- [-UserPrincipalName <String>] [-UserType <String>] [<CommonParameters>]
+ -UserPrincipalName <String> [-UserType <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -76,6 +76,29 @@ ObjectId                             DisplayName UserPrincipalName              
 
 In the first step we create a new object called "$extension" with object type "System.Collections.Generic.Dictionary". In the next step we add the extensionattribute 's name and value to the new object, and we display the object to see that we indeed created the correct object to serve as a parameter for the New-AzureADUser cmdlet.
 In the last step we create the new user and set the extension attribute value.
+	### Example 3: Create a user for use with a federated domain
+ ```powershell
+#Where Federated.Contoso.com is a Federated domain, ImmutableID is required
+New-AzureADUser -DisplayName "NewUser" -PasswordProfile $PasswordProfile -UserPrincipalName "NewUser@Federated.Contoso.com" -AccountEnabled $true -MailNickName "NewUser" -ImmutableID 'JQBJ4izMgEi8btONjOqIDA=='
+```
+```
+ObjectId                             DisplayName UserPrincipalName                 UserType
+--------                             ----------- -----------------                 --------
+5e8b0f4d-2cd4-4e17-9467-b0f6a5c0c4d0 NewUser     NewUser@Federated.Contoso.com     Member
+```
+ This creates a new user and associates it to a federated account with the specified ImmutableID
+
+### Example 3: Create a user for use with a federated domain
+ ```powershell
+#Where Federated.Contoso.com is a Federated domain, so ImmutableID is required
+New-AzureADUser -DisplayName "NewUser" -PasswordProfile $PasswordProfile -UserPrincipalName "NewUser@Federated.Contoso.com" -AccountEnabled $true -MailNickName "NewUser" -ImmutableID 'JQBJ4izMgEi8btONjOqIDA=='
+```
+```
+ObjectId                             DisplayName UserPrincipalName                 UserType
+--------                             ----------- -----------------                 --------
+5e8b0f4d-2cd4-4e17-9467-b0f6a5c0c4d0 NewUser     NewUser@Federated.Contoso.com     Member
+```
+ This creates a new user and associates it to a federated account with the specified ImmutableID
 
 ## PARAMETERS
 
@@ -493,7 +516,7 @@ Type: String
 Parameter Sets: (All)
 Aliases: 
 
-Required: False
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/azureadps-2.0/AzureAD/New-AzureADUser.md
+++ b/azureadps-2.0/AzureAD/New-AzureADUser.md
@@ -76,17 +76,6 @@ ObjectId                             DisplayName UserPrincipalName              
 
 In the first step we create a new object called "$extension" with object type "System.Collections.Generic.Dictionary". In the next step we add the extensionattribute 's name and value to the new object, and we display the object to see that we indeed created the correct object to serve as a parameter for the New-AzureADUser cmdlet.
 In the last step we create the new user and set the extension attribute value.
-	### Example 3: Create a user for use with a federated domain
- ```powershell
-#Where Federated.Contoso.com is a Federated domain, ImmutableID is required
-New-AzureADUser -DisplayName "NewUser" -PasswordProfile $PasswordProfile -UserPrincipalName "NewUser@Federated.Contoso.com" -AccountEnabled $true -MailNickName "NewUser" -ImmutableID 'JQBJ4izMgEi8btONjOqIDA=='
-```
-```
-ObjectId                             DisplayName UserPrincipalName                 UserType
---------                             ----------- -----------------                 --------
-5e8b0f4d-2cd4-4e17-9467-b0f6a5c0c4d0 NewUser     NewUser@Federated.Contoso.com     Member
-```
- This creates a new user and associates it to a federated account with the specified ImmutableID
 
 ### Example 3: Create a user for use with a federated domain
  ```powershell

--- a/azureadps-2.0/AzureAD/New-AzureADUser.md
+++ b/azureadps-2.0/AzureAD/New-AzureADUser.md
@@ -18,7 +18,7 @@ Creates an AD user.
 New-AzureADUser [-ExtensionProperty <System.Collections.Generic.Dictionary`2[System.String,System.String]>]
  -AccountEnabled <Boolean> [-City <String>] [-Country <String>] [-CreationType <String>] [-Department <String>]
  -DisplayName <String> [-FacsimileTelephoneNumber <String>] [-GivenName <String>] [-IsCompromised <Boolean>]
- [-ImmutableId <String>] [-JobTitle <String>] [-MailNickName <String>] [-Mobile <String>]
+ [-ImmutableId <String>] [-JobTitle <String>] -MailNickName <String> [-Mobile <String>]
  [-OtherMails <System.Collections.Generic.List`1[System.String]>] [-PasswordPolicies <String>]
  -PasswordProfile <PasswordProfile> [-PhysicalDeliveryOfficeName <String>] [-PostalCode <String>]
  [-PreferredLanguage <String>] [-ShowInAddressList <Boolean>]
@@ -252,7 +252,7 @@ Type: String
 Parameter Sets: (All)
 Aliases: 
 
-Required: False
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False


### PR DESCRIPTION
It seems like MailNickName and UserPrincipalName are required? 
Without the code it's hard to know for sure, but whatever API the Cmdlet is using seems to require the MailNickname and UserPrincipalName parameters, and the examples use them, even though the Docs page don't list them as required, and the `get-help New-AzureADUser -ShowWindow` also shows them as not required.  

I know MailNickName is linked to the SamAccountName on premises in many cases, and `-UserPrincipalName` might be important for the sign in name, wondering if maybe it would create the field from the UPN. It doesn't matter much, just one or two more params to pass, but we should update the docs to show it as required if it's being required by the API, or setup param sets if there is a case where it is not required, or adjust the API (and the param sets) to calculate it from some other field (and update the docs to reflect the formulaic nature if not provided) 

Wish I could be more help other than "This doesn't look right" but I can't access the code :( 
oh,, just as I was writing this up I found the Azure AD Graph API [users documentation](https://msdn.microsoft.com/Library/Azure/Ad/Graph/api/users-operations#CreateUser) that it seems to be using.  so it's showing that the required params are 
accountEnabled, displayname, mailNickname, passwordProfile, userPrincipalName and ImmutableID if UPN is for a federated domain

anywho, example of it being required
```powershell
$PasswordProfile = New-Object -TypeName Microsoft.Open.AzureAD.Model.PasswordProfile
$PasswordProfile.Password = "P@ssw0rd"

New-AzureADUser -AccountEnabled $true -PasswordProfile $PasswordProfile -DisplayName "Joe Bob" 
```
results in
```
New-AzureADUser : Error occurred while executing NewUser
Code: Request_BadRequest
Message: Property mailNickname value is required but is empty or missing.
RequestId: a4a70c1b-c0e3-44d0-8fd3-ac8ac5e388e0
DateTimeStamp: Sun, 04 Nov 2018 04:53:47 GMT
Details: PropertyName  - mailNickname, PropertyErrorCode  - PropertyRequired
HttpStatusCode: BadRequest
HttpStatusDescription: Bad Request
HttpResponseStatus: Completed

At C:\Users\KevinC\Downloads\Untitled-1.ps1:4 char:1
+ New-AzureADUser -AccountEnabled $true -PasswordProfile $PasswordProfi ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [New-AzureADUser], ApiException
    + FullyQualifiedErrorId : Microsoft.Open.AzureAD16.Client.ApiException,Microsoft.Open.AzureAD16.PowerShell.NewUser
```

A working version looks like the below 
```powershell
$PasswordProfile = New-Object -TypeName Microsoft.Open.AzureAD.Model.PasswordProfile
$PasswordProfile.Password = "P@ssw0rd"

New-AzureADUser -AccountEnabled $true -PasswordProfile $PasswordProfile -DisplayName "Joe Bob" -MailNickName "joebob" -UserPrincipalName "joebob@absurdcanoe.onmicrosoft.com"
``` 
and works Splendidly, If I add either only mailnickname or userprincipalname then it complains about the absence of the other very similar to the above error.
