### PR TITLE
Correct example in Remove-MsolGroupMember

### DIFF
--- a/azureadps-1.0/MSOnline/Remove-MsolGroupMember.md
+++ b/azureadps-1.0/MSOnline/Remove-MsolGroupMember.md
@@ -27,8 +27,8 @@ This member can be either a user or a group.
 
 ### Example 1: Remove a user from a group
 ```
-PS C:\> $GroupId = Get-MsolGroup -SearchString "MyGroup"
-PS C:\> $UserId = Get-MsolUser -UserPrincipalName "evannarvaez@contoso.com"
+PS C:\> $GroupId = (Get-MsolGroup -SearchString "MyGroup").ObjectId
+PS C:\> $UserId = (Get-MsolUser -UserPrincipalName "evannarvaez@contoso.com").ObjectId
 PS C:\> Remove-MsoLGroupMember -GroupObjectId $GroupId -GroupMemberType User -GroupmemberObjectId $UserId
 ```
 This example removes the user evannarvaez@contoso.com from the group named MyGroup.


### PR DESCRIPTION
I fixed the example to make it working. You cannot pass group/user objects where `Guid` is required.