### PR TITLE
Example 1 does not work

### DIFF
--- a/azureadps-2.0/AzureAD/Set-AzureADUser.md
+++ b/azureadps-2.0/AzureAD/Set-AzureADUser.md
@@ -35,9 +35,9 @@ The **Set-AzureADUser** cmdlet updates a user in Azure Active Directory (AD).
 
 ### Example 1: Update a user
 ```
-PS C:\> $user = Get-AzureADUser -ObjectId TestUser@example.com 
+PS C:\> $user = Get-AzureADUser | Where-Object {$_.UserPrincipalName -like "TestUser@example.com"}
 PS C:\> $user.DisplayName = 'YetAnotherTestUser' 
-PS C:\> Set-AzureADUser -ObjectId TestUser@example.com -Displayname $user.Displayname
+PS C:\> Set-AzureADUser -ObjectId $user.ObjectId -Displayname $user.Displayname
 ```
 
 This command updates the specified user's property.


### PR DESCRIPTION
An UPN cannot be submitted for ObjectID, either update the example to show inputting an object ID directly or add a Where-Object to lookup the object based on UPN.