### PR TITLE
Connect with AccessToken requires TenantID

### DIFF
--- a/azureadps-2.0/AzureAD/Connect-AzureAD.md
+++ b/azureadps-2.0/AzureAD/Connect-AzureAD.md
@@ -30,7 +30,7 @@ Connect-AzureAD [-AzureEnvironmentName <EnvironmentName>] -TenantId <String> -Ce
 
 ### AccessToken
 ```
-Connect-AzureAD [-AzureEnvironmentName <EnvironmentName>] [-TenantId <String>] -AadAccessToken <String>
+Connect-AzureAD [-AzureEnvironmentName <EnvironmentName>] -TenantId <String> -AadAccessToken <String>
  [-MsAccessToken <String>] -AccountId <String> [-LogLevel <LogLevel>] [-LogFilePath <String>]
  [-InformationAction <ActionPreference>] [-InformationVariable <String>] [-WhatIf] [-Confirm]
  [<CommonParameters>]


### PR DESCRIPTION
When using an Access Token it's required also to past the TenantID parameter.