### PR TITLE
Update signing-in-service-principal.md

### DIFF
--- a/docs-conceptual/azureadps-2.0/signing-in-service-principal.md
+++ b/docs-conceptual/azureadps-2.0/signing-in-service-principal.md
@@ -30,10 +30,11 @@ Connect-AzureAD
 ## Create a self signed certificate
 
 We'll use a self signed certificate for this example, so let's create one. You'll want to replace the <password> string inthe below example with a password of your choice, this is the password that is used to create the certificate file.
+This command does not specify the NotAfter parameter. Therefore, the certificate expires in one year.
 
 ```powershell
 $pwd = "<password>"
-$thumb = (New-SelfSignedCertificate -DnsName "drumkit.onmicrosoft.com" -CertStoreLocation "cert:\LocalMachine\My"  -KeyExportPolicy Exportable -Provider "Microsoft Enhanced RSA and AES Cryptographic Provider" -NotAfter $notAfter).Thumbprint
+$thumb = (New-SelfSignedCertificate -DnsName "drumkit.onmicrosoft.com" -CertStoreLocation "cert:\LocalMachine\My"  -KeyExportPolicy Exportable -Provider "Microsoft Enhanced RSA and AES Cryptographic Provider").Thumbprint
 $pwd = ConvertTo-SecureString -String $pwd -Force -AsPlainText
 Export-PfxCertificate -cert "cert:\localmachine\my\$thumb" -FilePath c:\temp\examplecert.pfx -Password $pwd
 ```


### PR DESCRIPTION
Command line 37 fails because $NotAfter is not defined:
New-SelfSignedCertificate : Cannot bind parameter 'NotAfter' to the target. Exception setting "NotAfter": "Cannot convert null to type "System.DateTime"."

I've removed the -notafter switch and added a note saying that, This command does not specify the NotAfter parameter. Therefore, the certificate expires in one year.

MFERRARI@MICROSOFT.COM