### PR TITLE
Replaced incorrect New example with Get example

### DIFF
--- a/azureadps-2.0/AzureAD/Get-AzureADApplicationPasswordCredential.md
+++ b/azureadps-2.0/AzureAD/Get-AzureADApplicationPasswordCredential.md
@@ -26,13 +26,13 @@ The **Get-AzureADApplicationPasswordCredential** cmdlet gets the password creden
 
 ### Example 1:
 ```
-PS C:\>New-AzureADApplicationPasswordCredential -ObjectId 3ddd22e7-a150-4bb3-b100-e410dea1cb84
+PS C:\>Get-AzureADApplicationPasswordCredential -ObjectId 3ddd22e7-a150-4bb3-b100-e410dea1cb84
 
 CustomKeyIdentifier :
-EndDate             : 9/28/2017 3:57:10 PM
-KeyId               :
-StartDate           : 9/28/2016 3:57:10 PM
-Value               : ZJ0V1Yg4cp4eWIey9DrYspqVdX1pdvY437P/ueGxVLU=
+EndDate             : 9/07/2020 11:43:54 PM
+KeyId               : 9787a870-1259-4532-bfb6-c27cca15b606
+StartDate           : 9/07/2019 11:43:54 PM
+Value               :
 ```
 
 ## PARAMETERS


### PR DESCRIPTION
Replaced the incorrect example of New-AzureADApplicationPasswordCredential command and output with the correct example of Get-AzureADApplicationPasswordCredential