### PR TITLE
Update SearchString parameter description

### DIFF
--- a/azureadps-2.0/AzureAD/Get-AzureADMSGroup.md
+++ b/azureadps-2.0/AzureAD/Get-AzureADMSGroup.md
@@ -146,7 +146,7 @@ Accept wildcard characters: False
 
 ### -SearchString
 Specifies a search string. 
-This cmdlet gets groups that have **DisplayName** or **Description** attributes that match the search string. 
+This cmdlet gets groups that have **DisplayName**, **mailNickname**, or **mail** attributes that match the search string. 
 
 ```yaml
 Type: String


### PR DESCRIPTION
Graph API does not support filtering Groups on Description field. The -SearchString param filters on group properties DisplayName/mailNickname/mail