### PR TITLE
Fixed issue #260 - MailNickname and UserPrincipalName are mandatory

### DIFF
--- a/azureadps-2.0-preview/AzureAD/New-AzureADUser.md
+++ b/azureadps-2.0-preview/AzureAD/New-AzureADUser.md
@@ -19,13 +19,13 @@ New-AzureADUser [-ExtensionProperty <System.Collections.Generic.Dictionary`2[Sys
  -AccountEnabled <Boolean> [-AgeGroup <String>] [-City <String>] [-CompanyName <String>]
  [-ConsentProvidedForMinor <String>] [-Country <String>] [-CreationType <String>] [-Department <String>]
  -DisplayName <String> [-FacsimileTelephoneNumber <String>] [-GivenName <String>] [-IsCompromised <Boolean>]
- [-ImmutableId <String>] [-JobTitle <String>] [-MailNickName <String>] [-Mobile <String>]
+ [-ImmutableId <String>] [-JobTitle <String>] -MailNickName <String> [-Mobile <String>]
  [-OtherMails <System.Collections.Generic.List`1[System.String]>] [-PasswordPolicies <String>]
  -PasswordProfile <PasswordProfile> [-PhysicalDeliveryOfficeName <String>] [-PostalCode <String>]
  [-PreferredLanguage <String>] [-ShowInAddressList <Boolean>]
  [-SignInNames <System.Collections.Generic.List`1[Microsoft.Open.AzureAD.Model.SignInName]>] [-State <String>]
  [-StreetAddress <String>] [-Surname <String>] [-TelephoneNumber <String>] [-UsageLocation <String>]
- [-UserPrincipalName <String>] [-UserState <String>] [-UserStateChangedOn <String>] [-UserType <String>]
+ -UserPrincipalName <String> [-UserState <String>] [-UserStateChangedOn <String>] [-UserType <String>]
  [<CommonParameters>]
 ```
 
@@ -35,8 +35,8 @@ The New-AzureADUser cmdlet creates a user in Azure Active Directory (AD).
 ## EXAMPLES
 
 ### Example 1: Create a user
-```
--AzureADUser -DisplayName "New User" -PasswordProfile $PasswordProfile -UserPrincipalName "NewUser@contoso.com" -AccountEnabled $true -MailNickName "Newuser"
+```powershell
+New-AzureADUser -DisplayName "New User" -PasswordProfile $PasswordProfile -UserPrincipalName "NewUser@contoso.com" -AccountEnabled $true -MailNickName "Newuser"
 
 ObjectId                             DisplayName UserPrincipalName               UserType
 --------                             ----------- -----------------               --------
@@ -226,7 +226,7 @@ Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -479,7 +479,7 @@ Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False


### PR DESCRIPTION
**MailNickname** & **UserPrincipalName** are mandatory parameters. It's correctly mentioned in the [Creating a new user in Azure AD](https://docs.microsoft.com/en-us/powershell/azure/active-directory/new-user-sample?view=azureadps-2.0) documentation, and also validated in PowerShell when running the cmdlet.