### PR TITLE
Fix example code in Working-with-Administrative-Units.md

### DIFF
--- a/docs-conceptual/azureadps-2.0/Working-with-Administrative-Units.md
+++ b/docs-conceptual/azureadps-2.0/Working-with-Administrative-Units.md
@@ -213,8 +213,7 @@ $adminunits = Get-AzureADAdministrativeUnit
 foreach($adminunit in $adminunits) {
     $adminScopes = Get-AzureADScopedRoleMembership -ObjectId $adminunit.ObjectId
     foreach($SRM in $UaAdminScopes) {
-        Remove-AzureADScopedRoleMembership -ObjectId $uaadmin.ObjectId -ScopedRoleMembershipId $SRM.Id
-        Remove-AzureADScopedRoleMembership -ObjectId $helpdeskadmin.ObjectId -ScopedRoleMembershipId $SRM.Id
+        Remove-AzureADScopedRoleMembership -ObjectId $adminunit.ObjectId -ScopedRoleMembershipId $SRM.Id
         }
     }
 # Check all scoped role memberships were deleted


### PR DESCRIPTION
ObjectId in `Remove-AzureADScopedRoleMembership` should be the `AdministrativeUnit` ObjectId, not the role which is what's used in the example (so doesn't work)