### PR TITLE
Removed  -NotAfter $notAfter

### DIFF
--- a/docs-conceptual/azureadps-2.0/signing-in-service-principal.md
+++ b/docs-conceptual/azureadps-2.0/signing-in-service-principal.md
@@ -33,7 +33,7 @@ We'll use a self signed certificate for this example, so let's create one. You'l
 
 ```powershell
 $pwd = "<password>"
-$thumb = (New-SelfSignedCertificate -DnsName "drumkit.onmicrosoft.com" -CertStoreLocation "cert:\LocalMachine\My"  -KeyExportPolicy Exportable -Provider "Microsoft Enhanced RSA and AES Cryptographic Provider" -NotAfter $notAfter).Thumbprint
+$thumb = (New-SelfSignedCertificate -DnsName "drumkit.onmicrosoft.com" -CertStoreLocation "cert:\LocalMachine\My"  -KeyExportPolicy Exportable -Provider "Microsoft Enhanced RSA and AES Cryptographic Provider").Thumbprint
 $pwd = ConvertTo-SecureString -String $pwd -Force -AsPlainText
 Export-PfxCertificate -cert "cert:\localmachine\my\$thumb" -FilePath c:\temp\examplecert.pfx -Password $pwd
 ```


### PR DESCRIPTION
$notAfter is not defined so it will throw an error. It is not needed either as New-SelfSignedCertificate will default to 1 year if -NotAfter is not specified