### PR TITLE
Dynamically determine ObjectId for "Directory Readers" role in Connect-AzureAD Example #2

### DIFF
--- a/azureadps-2.0-preview/AzureAD/Connect-AzureAD.md
+++ b/azureadps-2.0-preview/AzureAD/Connect-AzureAD.md
@@ -95,12 +95,13 @@ New-AzureADApplicationKeyCredential -ObjectId $application.ObjectId -CustomKeyId
 $sp=New-AzureADServicePrincipal -AppId $application.AppId
 
 # Give the Service Principal Reader access to the current tenant (Get-AzureADDirectoryRole)
-Add-AzureADDirectoryRoleMember -ObjectId 5997d714-c3b5-4d5b-9973-ec2f38fd49d5 -RefObjectId $sp.ObjectId
+$role = Get-AzureADDirectoryRole -Filter "DisplayName eq 'Directory Readers'"
+Add-AzureADDirectoryRoleMember -ObjectId $role.ObjectId -RefObjectId $sp.ObjectId
 
 # Get Tenant Detail
 $tenant=Get-AzureADTenantDetail
 # Now you can login to Azure PowerShell with your Service Principal and Certificate
-Connect-AzureAD -TenantId $tenant.ObjectId -ApplicationId  $sp.AppId -CertificateThumbprint $thumb
+Connect-AzureAD -TenantId $tenant.ObjectId -ApplicationId $sp.AppId -CertificateThumbprint $thumb
 ```
 
 This command authenticates the user to Azure Active Directory as a service principal.

--- a/azureadps-2.0/AzureAD/Connect-AzureAD.md
+++ b/azureadps-2.0/AzureAD/Connect-AzureAD.md
@@ -95,12 +95,13 @@ New-AzureADApplicationKeyCredential -ObjectId $application.ObjectId -CustomKeyId
 $sp = New-AzureADServicePrincipal -AppId $application.AppId
 
 # Give the Service Principal Reader access to the current tenant (Get-AzureADDirectoryRole)
-Add-AzureADDirectoryRoleMember -ObjectId 5997d714-c3b5-4d5b-9973-ec2f38fd49d5 -RefObjectId $sp.ObjectId
+$role = Get-AzureADDirectoryRole -Filter "DisplayName eq 'Directory Readers'"
+Add-AzureADDirectoryRoleMember -ObjectId $role.ObjectId -RefObjectId $sp.ObjectId
 
 # Get Tenant Detail
 $tenant = Get-AzureADTenantDetail
 # Now you can login to Azure PowerShell with your Service Principal and Certificate
-Connect-AzureAD -TenantId $tenant.ObjectId -ApplicationId  $sp.AppId -CertificateThumbprint $thumb
+Connect-AzureAD -TenantId $tenant.ObjectId -ApplicationId $sp.AppId -CertificateThumbprint $thumb
 ```
 
 This command authenticates the user to Azure Active Directory as a service principal.


### PR DESCRIPTION
The current example references the ObjectId of a role that is no longer valid.
![image](https://user-images.githubusercontent.com/15660532/71568275-ff4cbe00-2a93-11ea-850b-666997e185cd.png)

The proposed modification uses Get-AzureADDirectoryRole cmdlet to retrieve the ObjectId for the "Directory Readers" role.