### PR TITLE
Added a default to notAfter to make it work.

### DIFF
--- a/docs-conceptual/azureadps-2.0/signing-in-service-principal.md
+++ b/docs-conceptual/azureadps-2.0/signing-in-service-principal.md
@@ -33,6 +33,7 @@ We'll use a self signed certificate for this example, so let's create one. You'l
 
 ```powershell
 $pwd = "<password>"
+$notAfter = (Get-Date).AddMonths(6) # Valid for 6 months
 $thumb = (New-SelfSignedCertificate -DnsName "drumkit.onmicrosoft.com" -CertStoreLocation "cert:\LocalMachine\My"  -KeyExportPolicy Exportable -Provider "Microsoft Enhanced RSA and AES Cryptographic Provider" -NotAfter $notAfter).Thumbprint
 $pwd = ConvertTo-SecureString -String $pwd -Force -AsPlainText
 Export-PfxCertificate -cert "cert:\localmachine\my\$thumb" -FilePath c:\temp\examplecert.pfx -Password $pwd


### PR DESCRIPTION
Current snippet won't work - if an user copy from the document and run in PowerShell prompt - as-is. Because the `$notAfter` variable is not defined, as it did for password. I have added a default value (6 months) for the `$notAfter` while declaring it.