### PR TITLE
Handle local time zones

### DIFF
--- a/azureadps-2.0/AzureAD/New-AzureADApplicationKeyCredential.md
+++ b/azureadps-2.0/AzureAD/New-AzureADApplicationKeyCredential.md
@@ -52,8 +52,14 @@ PS C:\> $bin = $cer.GetRawCertData()
 PS C:\> $base64Value = [System.Convert]::ToBase64String($bin)
 PS C:\> $bin = $cer.GetCertHash()
 PS C:\> $base64Thumbprint = [System.Convert]::ToBase64String($bin)
-PS C:\> $keyid = [System.Guid]::NewGuid().ToString() 
-PS C:\> New-AzureADApplicationKeyCredential -ObjectId 009d786a-3503-4217-b8ab-db03d71c179a -CustomKeyIdentifier $base64Thumbprint  -Type AsymmetricX509Cert -Usage Verify -Value $base64Value -StartDate $cer.GetEffectiveDateString() -EndDate $cer.GetExpirationDateString()
+PS C:\> $keyid = [System.Guid]::NewGuid().ToString()
+PS C:\> $validFrom = [datetime]::Parse($cer.GetExpirationDateString())
+PS C:\> $validFrom = [System.TimeZoneInfo]::ConvertTimeBySystemTimeZoneId($validFrom, [System.TimeZoneInfo]::Local.Id, 'GMT Standard Time')
+PS C:\> $validFrom = $validFrom.ToString("yyyy-MM-dd hh:mm:ss")
+PS C:\> $validTo = [datetime]::Parse($cer.GetExpirationDateString())
+PS C:\> $validTo = [System.TimeZoneInfo]::ConvertTimeBySystemTimeZoneId($validTo, [System.TimeZoneInfo]::Local.Id, 'GMT Standard Time')
+PS C:\> $validTo = $validTo.ToString("yyyy-MM-dd hh:mm:ss")
+PS C:\> New-AzureADApplicationKeyCredential -ObjectId 009d786a-3503-4217-b8ab-db03d71c179a -CustomKeyIdentifier $base64Thumbprint  -Type AsymmetricX509Cert -Usage Verify -Value $base64Value -StartDate $validFrom -EndDate $validTo
 ```
 
 The first seven commands create values for the application key credential and stores them in variables.


### PR DESCRIPTION
The current example for creating key credential from cer-file assumes that the code is running in the GMT time zones. I have added the code required to convert the local `DateTime` object to GMT and format it in the same way as `$cer.GetExpirationDateString()`.