### PR TITLE
Example show different list type of RemoveLicenses

### DIFF
--- a/azureadps-2.0/AzureAD/Set-AzureADUserLicense.md
+++ b/azureadps-2.0/AzureAD/Set-AzureADUserLicense.md
@@ -41,6 +41,7 @@ $licenses.AddLicenses = $license
 Set-AzureADUserLicense -ObjectId "Violeta.Collias@drumkit.onmicrosoft.com" -AssignedLicenses $licenses
 
 $Licenses.AddLicenses = @()
+# Note that RemoveLicenses is a list of SkuID strings, and not objects like AddLicenses
 $Licenses.RemoveLicenses =  (Get-AzureADSubscribedSku | Where-Object -Property SkuPartNumber -Value "O365_BUSINESS_PREMIUM" -EQ).SkuID
 Set-AzureADUserLicense -ObjectId "Violeta.Collias@drumkit.onmicrosoft.com" -AssignedLicenses $licenses 
 ```


### PR DESCRIPTION
Me and multiple folk on the internet didn't spot the following description text, so highlight that in the example.
+ AddLicenses is list that contains objects of the type Microsoft.Open.AzureAD.Model.AssignedLicense
+ RemoveLicenses is a list that contains objects of the type String