### PR TITLE
Update New-AzureADMSGroup.md

### DIFF
--- a/azureadps-2.0/AzureAD/New-AzureADMSGroup.md
+++ b/azureadps-2.0/AzureAD/New-AzureADMSGroup.md
@@ -10,6 +10,9 @@ schema: 2.0.0
 ## SYNOPSIS
 Creates an Azure AD group.
 
+>[!Note]
+> This command currently requires the AzureADPreview module
+
 ## SYNTAX
 
 ```


### PR DESCRIPTION
This command in the *AzureAD* module is broken; it throws an errors if the *-MembershipRule* switch is included and throws a different error if it's not included. The command works as expected in the *AzureADPreview* module however and I've added a note at the beginning to let users know they currently need to use the preview module.