### PR TITLE
Resource category corrected

### DIFF
--- a/azureadps-2.0-preview/AzureAD/New-AzureADMSRoleDefinition.md
+++ b/azureadps-2.0-preview/AzureAD/New-AzureADMSRoleDefinition.md
@@ -28,7 +28,7 @@ The New-AzureADMSRoleDefinition cmdlet creates an Azure Active Directory (Azure 
 ```
 PS C:\> 
 $allowedResourceAction = @()
-$allowedResourceAction += @("microsoft.aad.directory/applications/create")
+$allowedResourceAction += @("microsoft.directory/applications/create")
 $rolePermission = @{'allowedResourceActions' = $allowedResourceAction}
 $rolePermissions = @()
 $rolePermissions += $rolePermission


### PR DESCRIPTION
The resource name microsoft.aad.directory is incorrect. Changed the example to use  an existing resource name "microsoft.directory/applications/create"