### PR TITLE
Update Set-MsolCompanySettings.md

### DIFF
--- a/azureadps-1.0/MSOnline/Set-MsolCompanySettings.md
+++ b/azureadps-1.0/MSOnline/Set-MsolCompanySettings.md
@@ -123,6 +123,10 @@ Accept wildcard characters: False
 ```
 
 ### -UsersPermissionToReadOtherUsersEnabled
+
+> [!NOTE]
+> Setting this to $False may have adverse impacts on many services in your tenant. For example, Team Owners will no longer be able to add members to a team.
+
 Indicates whether to allow users to view the profile info of other users in their company.
 This setting is applied company-wide.
 Set to $False to disable users' ability to use the Azure AD module for Windows PowerShell to access user information for their organization.


### PR DESCRIPTION
Added an advisory note to the -UsersPermissionToReadOtherUsersEnabled parameter to warn of implications of setting the boolean value to $False. Setting this to false will result in tenant wide issues where Team owners can no longer add Members to the teams they are Owners of.