### PR TITLE
Update Working-with-Administrative-Units.md

### DIFF
--- a/docs-conceptual/azureadps-2.0/Working-with-Administrative-Units.md
+++ b/docs-conceptual/azureadps-2.0/Working-with-Administrative-Units.md
@@ -100,7 +100,7 @@ Get-AzureADAdministrativeUnitMember -ObjectId $eastCoastAU.ObjectId | Get-AzureA
 ### Get list of available roles
 $admins = Get-AzureADDirectoryRole
 foreach($i in $admins) {
-    if($i.DisplayName -eq "User Account Administrator") {
+    if($i.DisplayName -eq "User Administrator") {
         $uaAdmin = $i
         }
     if($i.DisplayName -eq "Helpdesk Administrator") {

--- a/docs-conceptual/azureadps-2.0/Working-with-Administrative-Units.md
+++ b/docs-conceptual/azureadps-2.0/Working-with-Administrative-Units.md
@@ -199,7 +199,7 @@ Connect-AzureAD
 ### Get roles used in demo
 $admins = Get-AzureADDirectoryRole
 foreach($i in $admins) {
-    if($i.DisplayName -eq "User Account Administrator") {
+    if($i.DisplayName -eq "User Administrator") {
         $uaadmin = $i
         }
     if($i.DisplayName -eq "Helpdesk Administrator") {


### PR DESCRIPTION
There is no role called "User Account Administrator". If one executes the command "Get-AzureADDirectoryRole", the actual role is called User Administrator. I've reflected this change in the script "Global Admin.ps1"