### PR TITLE
Correct Example 4

### DIFF
--- a/azureadps-2.0-preview/AzureAD/Get-AzureADAuditSignInLogs.md
+++ b/azureadps-2.0-preview/AzureAD/Get-AzureADAuditSignInLogs.md
@@ -47,7 +47,7 @@ This command shows how to get audit logs by location
 
 ### Example 4: Get all sign in logs with a given status
 ```
-PS C:\>Get-AzureADAuditSignInLogs -Filter "status/errorCode eq 0 -All $true"
+PS C:\>Get-AzureADAuditSignInLogs -Filter "status/errorCode eq 0" -All $true
 PS C:\>Get-AzureADAuditSignInLogs -Filter "status/errorCode ne 0"
 ```
 


### PR DESCRIPTION
Example 4 had the trailing quotation mark in the wrong position.