### PR TITLE
Changed Example to use Get-MsolRoleMember instead of Get-MsolRole

### DIFF
--- a/azureadps-1.0/MSOnline/Get-MsolRoleMember.md
+++ b/azureadps-1.0/MSOnline/Get-MsolRoleMember.md
@@ -33,7 +33,8 @@ The **Get-MsolRoleMember** cmdlet gets members of the specified role.
 
 ### Example 1: Get members of a role
 ```
-PS C:\> $RoleMembers = Get-MsolRole -RoleName "Company Administrator"
+PS C:\> $Role = Get-MsolRole -RoleName "%Role Name%"
+PS C:\> $RoleMembers = Get-MsolRoleMember -RoleObjectId $Role.ObjectId
 ```
 
 This command returns all the members of the specified role.


### PR DESCRIPTION
The original example was actually just getting the roles for a tenancy and did not use the command for which this help is for. Updated example to get role members