### PR TITLE
Update Set-AzureADMSPrivilegedRoleSetting.md

### DIFF
--- a/azureadps-2.0-preview/AzureAD/Set-AzureADMSPrivilegedRoleSetting.md
+++ b/azureadps-2.0-preview/AzureAD/Set-AzureADMSPrivilegedRoleSetting.md
@@ -31,7 +31,7 @@ Update role setting
 ```
 PS C:\> $setting = New-Object Microsoft.Open.MSGraph.Model.AzureADMSPrivilegedRuleSetting
 				  PS C:\> $setting.RuleIdentifier = "JustificationRule"
-				  PS C:\> $setting.Setting = "{'required':false}"
+				  PS C:\> $setting.Setting = "{`"required`":false}"
 				  PS C:\> Set-AzureADMSPrivilegedRoleSetting -ProviderId AzureResources -Id ff518d09-47f5-45a9-bb32-71916d9aeadf -ResourceId 3f5887ed-dd6e-4821-8bde-c813ec508cf9 -RoleDefinitionId 2387ced3-4e95-4c36-a915-73d803f93702 -UserMemberSettings $setting
 ```
 


### PR DESCRIPTION
Single quotes ' is invalid JSON, which breaks the role setting. Instead, escape double quotes inside of a string using the tick character `