### PR TITLE
Id is required when passing InputFilePath (for Set-AzureADMSTrustFrameworkPolicy)

### DIFF
--- a/azureadps-2.0-preview/AzureAD/Set-AzureADMSTrustFrameworkPolicy.md
+++ b/azureadps-2.0-preview/AzureAD/Set-AzureADMSTrustFrameworkPolicy.md
@@ -20,7 +20,7 @@ Set-AzureADMSTrustFrameworkPolicy [-Id <String>] [-OutputFilePath <String>] -Con
 
 ### File
 ```
-Set-AzureADMSTrustFrameworkPolicy [-Id <String>] -InputFilePath <String> [-OutputFilePath <String>]
+Set-AzureADMSTrustFrameworkPolicy -Id <String> -InputFilePath <String> [-OutputFilePath <String>]
  [<CommonParameters>]
 ```
 
@@ -94,7 +94,7 @@ Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False


### PR DESCRIPTION
I'm using AzureADPreview 2.0.2.138.

When I run 
```
Set-AzureADMSTrustFrameworkPolicy -InputFilePath TrustFrameworkBase.xml
```
It throws an error
```
Set-AzureADMSTrustFrameworkPolicy : Cannot process command because of one or more missing mandatory parameters: Id.
```

The doc right now says `Id` is not required, but the implementation requires the Id param when passing InputFilePath. I think we should update it.

Please feel free to correct me if I am wrong somewhere or if I misunderstand anything. Thanks