### PR TITLE
Fixing whitespace missing in Type parameter

### DIFF
--- a/azureadps-2.0-preview/.vscode/settings.json
+++ b/azureadps-2.0-preview/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "markdownlint.config": {
+        "MD028": false,
+        "MD025": {
+            "front_matter_title": ""
+        }
+    }
+}

--- a/azureadps-2.0-preview/AzureAD/Add-AzureADMScustomSecurityAttributeDefinitionAllowedValues.md
+++ b/azureadps-2.0-preview/AzureAD/Add-AzureADMScustomSecurityAttributeDefinitionAllowedValues.md
@@ -1,0 +1,95 @@
+---
+external help file: Microsoft.Open.MS.GraphBeta.PowerShell.dll-Help.xml
+Module Name: AzureADPreview
+online version:
+schema: 2.0.0
+---
+
+# Add-AzureADMScustomSecurityAttributeDefinitionAllowedValues
+
+## SYNOPSIS
+Adds a predefined value for a custom security attribute definition.
+
+## SYNTAX
+
+```
+Add-AzureADMScustomSecurityAttributeDefinitionAllowedValues -CustomSecurityAttributeDefinitionId <String>
+ -Id <String> -IsActive <Boolean> [<CommonParameters>]
+```
+
+## DESCRIPTION
+Adds a predefined value for a Azure Active Directory (Azure AD) custom security attribute definition.
+
+## EXAMPLES
+
+### Example
+```powershell
+Add-AzureADMScustomSecurityAttributeDefinitionAllowedValues -CustomSecurityAttributeDefinitionId Engineering_Project -Id "Alpine" -IsActive $true
+```
+
+Add a predefined value:
+
+- Attribute set: `Engineering`
+- Attribute: `Project`
+- Predefined value: `Alpine`
+
+## PARAMETERS
+
+### -CustomSecurityAttributeDefinitionId
+The unique identifier for a custom security attribute definition in Azure AD.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -Id
+The unique identifier of an object in Azure AD.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IsActive
+Indicates whether the predefined value is active or deactivated. If set to false, this predefined value cannot be assigned to any additional supported directory objects.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/azureadps-2.0-preview/AzureAD/Get-AzureADMSAttributeSet.md
+++ b/azureadps-2.0-preview/AzureAD/Get-AzureADMSAttributeSet.md
@@ -1,0 +1,75 @@
+---
+external help file: Microsoft.Open.MS.GraphBeta.PowerShell.dll-Help.xml
+Module Name: AzureADPreview
+online version:
+schema: 2.0.0
+---
+
+# Get-AzureADMSAttributeSet
+
+## SYNOPSIS
+Gets a list of attribute sets.
+
+## SYNTAX
+
+### GetQuery (Default)
+```
+Get-AzureADMSAttributeSet [<CommonParameters>]
+```
+
+### GetById
+```
+Get-AzureADMSAttributeSet -Id <String> [<CommonParameters>]
+```
+
+## DESCRIPTION
+Gets a list of Azure Active Directory (Azure AD) attribute sets.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+Get-AzureADMSAttributeSet
+```
+
+Get all attribute sets.
+
+### Example 2
+```powershell
+Get-AzureADMSAttributeSet -Id "Engineering"
+```
+
+Get an attribute set.
+
+- Attribute set: `Engineering`
+
+## PARAMETERS
+
+### -Id
+The unique identifier of an Azure AD attribute set object.
+
+```yaml
+Type: String
+Parameter Sets: GetById
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/azureadps-2.0-preview/AzureAD/Get-AzureADMSCustomSecurityAttributeDefinition.md
+++ b/azureadps-2.0-preview/AzureAD/Get-AzureADMSCustomSecurityAttributeDefinition.md
@@ -1,0 +1,76 @@
+---
+external help file: Microsoft.Open.MS.GraphBeta.PowerShell.dll-Help.xml
+Module Name: AzureADPreview
+online version:
+schema: 2.0.0
+---
+
+# Get-AzureADMSCustomSecurityAttributeDefinition
+
+## SYNOPSIS
+Gets a list of custom security attribute definitions.
+
+## SYNTAX
+
+### GetQuery (Default)
+```
+Get-AzureADMSCustomSecurityAttributeDefinition [<CommonParameters>]
+```
+
+### GetById
+```
+Get-AzureADMSCustomSecurityAttributeDefinition -Id <String> [<CommonParameters>]
+```
+
+## DESCRIPTION
+Gets a list of Azure Active Directory (Azure AD) custom security attribute definitions.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+Get-AzureADMSCustomSecurityAttributeDefinition
+```
+
+Get all custom security attribute definitions.
+
+### Example 2
+```powershell
+Get-AzureADMSCustomSecurityAttributeDefinition -Id "Engineering_ProjectDate" 
+```
+
+Get a custom security attribute definition.
+
+- Attribute set: `Engineering`
+- Attribute: `ProjectDate`
+
+## PARAMETERS
+
+### -Id
+The unique identifier of an Azure AD custom security attribute definition object.
+
+```yaml
+Type: String
+Parameter Sets: GetById
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/azureadps-2.0-preview/AzureAD/Get-AzureADMSCustomSecurityAttributeDefinitionAllowedValue.md
+++ b/azureadps-2.0-preview/AzureAD/Get-AzureADMSCustomSecurityAttributeDefinitionAllowedValue.md
@@ -1,0 +1,115 @@
+---
+external help file: Microsoft.Open.MS.GraphBeta.PowerShell.dll-Help.xml
+Module Name: AzureADPreview
+online version:
+schema: 2.0.0
+---
+
+# Get-AzureADMSCustomSecurityAttributeDefinitionAllowedValue
+
+## SYNOPSIS
+Gets the predefined value for a custom security attribute definition.
+
+## SYNTAX
+
+### GetQuery (Default)
+```
+Get-AzureADMSCustomSecurityAttributeDefinitionAllowedValue -CustomSecurityAttributeDefinitionId <String>
+ [-Filter <String>] [<CommonParameters>]
+```
+
+### GetById
+```
+Get-AzureADMSCustomSecurityAttributeDefinitionAllowedValue -CustomSecurityAttributeDefinitionId <String>
+ -Id <String> [<CommonParameters>]
+```
+
+## DESCRIPTION
+Gets the predefined value for an Azure Active Directory (Azure AD) custom security attribute definition.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+Get-AzureADMSCustomSecurityAttributeDefinitionAllowedValue -CustomSecurityAttributeDefinitionId "Engineering_Project"
+```
+
+Get all predefined values.
+
+- Attribute set: `Engineering`
+- Attribute: `Project`
+
+### Example 2
+```powershell
+Get-AzureADMSCustomSecurityAttributeDefinitionAllowedValue -CustomSecurityAttributeDefinitionId "Engineering_Project" -Id "Alpine"
+```
+
+Get a predefined value.
+
+- Attribute set: `Engineering`
+- Attribute: `Project`
+- Predefined value: `Alpine`
+
+## PARAMETERS
+
+### -CustomSecurityAttributeDefinitionId
+The unique identifier of a custom security attribute definition in Azure AD.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -Filter
+Specifies an oData v3.0 filter statement.
+This parameter controls which objects are returned.
+Details on querying with oData can be found here.
+http://www.odata.org/documentation/odata-version-3-0/odata-version-3-0-core-protocol/#queryingcollections
+
+```yaml
+Type: String
+Parameter Sets: GetQuery
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -Id
+The unique identifier of a predefined value in Azure AD.
+
+```yaml
+Type: String
+Parameter Sets: GetById
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/azureadps-2.0-preview/AzureAD/Get-AzureADMSServicePrincipal.md
+++ b/azureadps-2.0-preview/AzureAD/Get-AzureADMSServicePrincipal.md
@@ -1,0 +1,203 @@
+---
+external help file: Microsoft.Open.MS.GraphBeta.PowerShell.dll-Help.xml
+Module Name: AzureADPreview
+online version:
+schema: 2.0.0
+---
+
+# Get-AzureADMSServicePrincipal
+
+## SYNOPSIS
+Gets a service principal.
+
+## SYNTAX
+
+### GetQuery (Default)
+```
+Get-AzureADMSServicePrincipal [-All <Boolean>] [-Top <Int32>] [-Filter <String>] [-Select <String>]
+ [<CommonParameters>]
+```
+
+### GetVague
+```
+Get-AzureADMSServicePrincipal [-SearchString <String>] [-All <Boolean>] [<CommonParameters>]
+```
+
+### GetById
+```
+Get-AzureADMSServicePrincipal -Id <String> [-All <Boolean>] [-Select <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+The Get-AzureADMSServicePrincipal cmdlet gets a service principal in Azure Active Directory (Azure AD).
+
+## EXAMPLES
+
+### Example 1
+```
+PS C:\> Get-AzureADMSServicePrincipal
+
+Id                                 : 055aa618-7c74-40ee-b278-75545562c3d6
+ObjectId                           :
+DeletionTimestamp                  :
+AccountEnabled                     : true
+AppId                              : 6ff5f225-c1d3-46cc-b89e-39e679ff746f
+AppDisplayName                     : App Name
+ApplicationTemplateId              :
+AppRoleAssignmentRequired          : False
+CustomSecurityAttributes           :
+DisplayName                        : App Name
+ErrorUrl                           :
+LogoutUrl                          :
+Homepage                           :
+IsManagementRestricted             :
+SamlMetadataUrl                    :
+MicrosoftFirstParty                :
+PublisherName                      : Microsoft Services
+PreferredTokenSigningKeyThumbprint :
+ReplyUrls                          : {}
+ServicePrincipalNames              : {6ff5f225-c1d3-46cc-b89e-39e679ff746f}
+Tags                               : {}
+KeyCredentials                     : {}
+PasswordCredentials                : {}
+```
+
+Get all service principals from the directory.
+
+### Example 2
+```powershell
+PS C:\> $sp = Get-AzureADMSServicePrincipal -Id 4a7c15df-ac88-44f3-84c6-fd0812701f29
+```
+
+Get a service principal by ID.
+
+### Example 3
+```powershell
+PS C:\> $ServicePrincipalId = (Get-AzureADMSServicePrincipal -Top 1).Id
+PS C:\> Get-AzureADMSServicePrincipal $ServicePrincipalId
+```
+
+The first command gets the ID of a service principal by using the Get-AzureADMSServicePrincipal cmdlet.
+The command stores the ID in the $ServicePrincipalId variable.
+
+The second command gets the service principal identified by $ServicePrincipalId.
+
+### Example 4
+```powershell
+PS C:\> Get-AzureADMSServicePrincipal -Select CustomSecurityAttributes
+Get-AzureADMSServicePrincipal -Id 7d194b0c-bf17-40ff-9f7f-4b671de8dc20  -Select "CustomSecurityAttributes, Id"
+```
+
+List custom security attribute assignments for an application (service principal).
+
+## PARAMETERS
+
+### -All
+If true, return all serviceprincipal objects.
+If false, return the number of objects specified by the Top parameter
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -Filter
+Specifies an oData v3.0 filter statement.
+This parameter controls which objects are returned.
+
+```yaml
+Type: String
+Parameter Sets: GetQuery
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -Id
+Specifies the ID of a service principal in Azure AD.
+
+```yaml
+Type: String
+Parameter Sets: GetById
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -SearchString
+Specifies a search string.
+
+```yaml
+Type: String
+Parameter Sets: GetVague
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -Select
+Specifies the properties to be returned on the object.
+
+```yaml
+Type: String
+Parameter Sets: GetQuery, GetById
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -Top
+Specifies the maximum number of records to return.
+
+```yaml
+Type: Int32
+Parameter Sets: GetQuery
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+### System.Nullable`1[[System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]
+
+### System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/azureadps-2.0-preview/AzureAD/Get-AzureADMSUser.md
+++ b/azureadps-2.0-preview/AzureAD/Get-AzureADMSUser.md
@@ -1,0 +1,162 @@
+---
+external help file: Microsoft.Open.MS.GraphBeta.PowerShell.dll-Help.xml
+Module Name: AzureADPreview
+online version:
+schema: 2.0.0
+---
+
+# Get-AzureADMSUser
+
+## SYNOPSIS
+Gets a user.
+
+## SYNTAX
+
+### GetQuery (Default)
+```
+Get-AzureADMSUser [-All <Boolean>] [-Top <Int32>] [-Select <String>] [-Filter <String>] [<CommonParameters>]
+```
+
+### GetVague
+```
+Get-AzureADMSUser [-SearchString <String>] [-All <Boolean>] [<CommonParameters>]
+```
+
+### GetById
+```
+Get-AzureADMSUser -Id <String> [-All <Boolean>] [-Select <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Gets a user in Azure Active Directory (Azure AD).
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> $user = Get-AzureADMSUser -UserPrincipalName TestUser@example.com 
+```
+
+Get a user by user principal name.
+
+### Example 2
+```powershell
+PS C:\> $user1 = Get-AzureADMSUser -Id dbb22700-a7de-4372-ae78-0098ee60e55e -Select CustomSecurityAttributes
+PS C:\> $user1.CustomSecurityAttributes
+```
+
+List custom security attribute assignments for a user.
+
+## PARAMETERS
+
+### -All
+If true, return all users.
+If false, return the number of objects specified by the Top parameter
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -Filter
+Specifies an oData v3.0 filter statement.
+This parameter controls which objects are returned.
+Details on querying with oData can be found here.
+http://www.odata.org/documentation/odata-version-3-0/odata-version-3-0-core-protocol/#queryingcollections
+
+```yaml
+Type: String
+Parameter Sets: GetQuery
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -Id
+Specifies the ID of a user in Azure AD.
+
+```yaml
+Type: String
+Parameter Sets: GetById
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -SearchString
+Specifies a search string.
+
+```yaml
+Type: String
+Parameter Sets: GetVague
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -Select
+Specifies the properties to be returned on the object.
+
+```yaml
+Type: String
+Parameter Sets: GetQuery, GetById
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -Top
+Specifies the maximum number of records to return.
+
+```yaml
+Type: Int32
+Parameter Sets: GetQuery
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+### System.Nullable`1[[System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]
+
+### System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/azureadps-2.0-preview/AzureAD/New-AzureADMSAttributeSet.md
+++ b/azureadps-2.0-preview/AzureAD/New-AzureADMSAttributeSet.md
@@ -1,0 +1,93 @@
+---
+external help file: Microsoft.Open.MS.GraphBeta.PowerShell.dll-Help.xml
+Module Name: AzureADPreview
+online version:
+schema: 2.0.0
+---
+
+# New-AzureADMSAttributeSet
+
+## SYNOPSIS
+Adds a new attribute set.
+
+## SYNTAX
+
+```
+New-AzureADMSAttributeSet [-Id <String>] [-Description <String>] [-MaxAttributesPerSet <Int32>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+Adds a new Azure Active Directory (Azure AD) attribute set object.
+
+## EXAMPLES
+
+### Example
+```powershell
+New-AzureADMSAttributeSet -Id "Engineering" -Description "Attributes for engineering team" -MaxAttributesPerSet 10
+```
+
+Add a single attribute set.
+
+- Attribute set: `Engineering`
+
+## PARAMETERS
+
+### -Description
+Description for the attribute set.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Id
+Name of the attribute set. Must be unique within a tenant.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MaxAttributesPerSet
+Maximum number of custom security attributes that can be defined in the attribute set.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/azureadps-2.0-preview/AzureAD/New-AzureADMSCustomSecurityAttributeDefinition.md
+++ b/azureadps-2.0-preview/AzureAD/New-AzureADMSCustomSecurityAttributeDefinition.md
@@ -1,0 +1,171 @@
+---
+external help file: Microsoft.Open.MS.GraphBeta.PowerShell.dll-Help.xml
+Module Name: AzureADPreview
+online version:
+schema: 2.0.0
+---
+
+# New-AzureADMSCustomSecurityAttributeDefinition
+
+## SYNOPSIS
+Adds a new custom security attribute definition.
+
+## SYNTAX
+
+```
+New-AzureADMSCustomSecurityAttributeDefinition -AttributeSet <String> [-Description <String>]
+ -IsCollection <Boolean> -IsSearchable <Boolean> -Name <String> -Status <String> -Type <String>
+ -UsePreDefinedValuesOnly <Boolean> [<CommonParameters>]
+```
+
+## DESCRIPTION
+Adds a new Azure Active Directory (Azure AD) custom security attribute definition object.
+
+## EXAMPLES
+
+### Example
+```powershell
+New-AzureADMSCustomSecurityAttributeDefinition -AttributeSet "Engineering" -Name "ProjectDate" -Description "Target completion date" -Type "String" -Status "Available" -IsCollection $false -IsSearchable $true -UsePreDefinedValuesOnly $true
+```
+
+Add a custom security attribute definition.
+
+- Attribute set: `Engineering`
+- Attribute: `ProjectDate`
+- Attribute data type: String
+
+## PARAMETERS
+
+### -AttributeSet
+Name of the attribute set in Azure AD.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Description
+Description for the custom security attribute definition.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IsCollection
+Indicates whether multiple values can be assigned to the custom security attribute.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IsSearchable
+Indicates whether custom security attribute values will be indexed for searching on objects that are assigned attribute values.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+Name of the custom security attribute. Must be unique within an attribute set.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Status
+Specifies whether the custom security attribute is active or deactivated. Acceptable values are 'Available' and 'Deprecated'.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Type
+Specifies the data type of the attribute.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UsePreDefinedValuesOnly
+Indicates whether only predefined values can be assigned to the custom security attribute. If set to false, free-form values are allowed.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/azureadps-2.0-preview/AzureAD/Open-AzureADMSPrivilegedRoleAssignmentRequest.md
+++ b/azureadps-2.0-preview/AzureAD/Open-AzureADMSPrivilegedRoleAssignmentRequest.md
@@ -148,7 +148,7 @@ Accept wildcard characters: False
 
 ### -Type
 The request type.
-The value can be AdminAdd, UserAdd, AdminUpdate, AdminRemove, UserRemove, UserExtend, UserRenew, AdminRenewand AdminExtend.
+The value can be AdminAdd, UserAdd, AdminUpdate, AdminRemove, UserRemove, UserExtend, UserRenew, AdminRenew and AdminExtend.
 Required.
 
 ```yaml

--- a/azureadps-2.0-preview/AzureAD/Set-AzureADMSAttributeSet.md
+++ b/azureadps-2.0-preview/AzureAD/Set-AzureADMSAttributeSet.md
@@ -1,0 +1,102 @@
+---
+external help file: Microsoft.Open.MS.GraphBeta.PowerShell.dll-Help.xml
+Module Name: AzureADPreview
+online version:
+schema: 2.0.0
+---
+
+# Set-AzureADMSAttributeSet
+
+## SYNOPSIS
+Updates an existing attribute set.
+
+## SYNTAX
+
+```
+Set-AzureADMSAttributeSet -Id <String> [-Description <String>] [-MaxAttributesPerSet <Int32>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+Updates an Azure Active Directory (Azure AD) attribute set object identified by ID.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+Set-AzureADMSAttributeSet -Id "Engineering" -Description "Attributes for cloud engineering team"
+```
+
+Update an attribute set.
+
+- Attribute set: `Engineering`
+
+### Example 2
+```powershell
+Set-AzureADMSAttributeSet -Id "Engineering" -MaxAttributesPerSet 20
+```
+
+Update an attribute set.
+
+- Attribute set: `Engineering`
+
+## PARAMETERS
+
+### -Description
+Description of the attribute set.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Id
+Name of the attribute set.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -MaxAttributesPerSet
+Maximum number of custom security attributes that can be defined in the attribute set.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/azureadps-2.0-preview/AzureAD/Set-AzureADMSCustomSecurityAttributeDefinition.md
+++ b/azureadps-2.0-preview/AzureAD/Set-AzureADMSCustomSecurityAttributeDefinition.md
@@ -1,0 +1,119 @@
+---
+external help file: Microsoft.Open.MS.GraphBeta.PowerShell.dll-Help.xml
+Module Name: AzureADPreview
+online version:
+schema: 2.0.0
+---
+
+# Set-AzureADMSCustomSecurityAttributeDefinition
+
+## SYNOPSIS
+Updates an existing custom security attribute definition.
+
+## SYNTAX
+
+```
+Set-AzureADMSCustomSecurityAttributeDefinition -Id <String> [-Description <String>] [-Status <String>]
+ [-UsePreDefinedValuesOnly <Boolean>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Updates an Azure Active Directory (Azure AD) custom security attribute definition object identified by ID.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+Set-AzureADMSCustomSecurityAttributeDefinition -Id "Engineering_ProjectDate" -Description "Target completion date (YYYY/MM/DD)"
+```
+
+Update a custom security attribute definition.
+
+- Attribute set: `Engineering`
+- Attribute: `ProjectDate`
+
+### Example 2
+```powershell
+Set-AzureADMSCustomSecurityAttributeDefinition -Id Engineering_Project -Status "Deprecated"
+```
+
+Deactivate a custom security attribute definition.
+
+- Attribute set: `Engineering`
+- Attribute: `Project`
+
+## PARAMETERS
+
+### -Description
+Description of the custom security attribute definition.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Id
+The unique identifier of a custom security attribute definition in Azure AD.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -Status
+Specifies whether the custom security attribute is active or deactivated. Acceptable values are 'Available' and 'Deprecated'.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UsePreDefinedValuesOnly
+Indicates whether only predefined values can be assigned to the custom security attribute.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/azureadps-2.0-preview/AzureAD/Set-AzureADMSCustomSecurityAttributeDefinitionAllowedValue.md
+++ b/azureadps-2.0-preview/AzureAD/Set-AzureADMSCustomSecurityAttributeDefinitionAllowedValue.md
@@ -1,0 +1,95 @@
+---
+external help file: Microsoft.Open.MS.GraphBeta.PowerShell.dll-Help.xml
+Module Name: AzureADPreview
+online version:
+schema: 2.0.0
+---
+
+# Set-AzureADMSCustomSecurityAttributeDefinitionAllowedValue
+
+## SYNOPSIS
+Updates an existing custom security attribute definition predefined value.
+
+## SYNTAX
+
+```
+Set-AzureADMSCustomSecurityAttributeDefinitionAllowedValue -CustomSecurityAttributeDefinitionId <String>
+ -Id <String> [-IsActive <Boolean>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Updates an Azure Active Directory (Azure AD) custom security attribute definition predefined value object identified by ID.
+
+## EXAMPLES
+
+### Example
+```powershell
+Set-AzureADMSCustomSecurityAttributeDefinitionAllowedValue -CustomSecurityAttributeDefinitionId "Engineering_Project" -Id "Alpine" -IsActive $false
+```
+
+Deactivate a predefined value.
+
+- Attribute set: `Engineering`
+- Attribute: `Project`
+- Predefined value: `Alpine`
+
+## PARAMETERS
+
+### -CustomSecurityAttributeDefinitionId
+The unique identifier of a custom security attribute definition in Azure AD.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -Id
+Predefined value for the custom security attribute.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -IsActive
+Specifies whether the predefined value is active or deactivated. If set to false, this predefined value cannot be assigned to any additional supported directory objects.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/azureadps-2.0-preview/AzureAD/Set-AzureADMSServicePrincipal.md
+++ b/azureadps-2.0-preview/AzureAD/Set-AzureADMSServicePrincipal.md
@@ -1,0 +1,363 @@
+---
+external help file: Microsoft.Open.MS.GraphBeta.PowerShell.dll-Help.xml
+Module Name: AzureADPreview
+online version:
+schema: 2.0.0
+---
+
+# Set-AzureADMSServicePrincipal
+
+## SYNOPSIS
+Updates a service principal.
+
+## SYNTAX
+
+```
+Set-AzureADMSServicePrincipal -Id <String> [-AccountEnabled <String>] [-AppId <String>]
+ [-AppRoleAssignmentRequired <Boolean>] [-CustomSecurityAttributes <Object>] [-DisplayName <String>]
+ [-ErrorUrl <String>] [-LogoutUrl <String>] [-Homepage <String>] [-SamlMetadataUrl <String>]
+ [-MicrosoftFirstParty <Boolean>] [-PublisherName <String>] [-PreferredTokenSigningKeyThumbprint <String>]
+ [-ReplyUrls <System.Collections.Generic.List`1[System.String]>]
+ [-ServicePrincipalNames <System.Collections.Generic.List`1[System.String]>]
+ [-Tags <System.Collections.Generic.List`1[System.String]>]
+ [-KeyCredentials <System.Collections.Generic.List`1[Microsoft.Open.MSGraph.Model.MsKeyCredential]>]
+ [-PasswordCredentials <System.Collections.Generic.List`1[Microsoft.Open.MSGraph.Model.MsPasswordCredential]>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+Updates a service principal in Azure Active Directory (Azure AD).
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Set-AzureADMSServicePrincipal -Id 2e0d8ca7-57d1-4a87-9c2a-b3638a4cadbf -AccountEnabled $False
+```
+
+This command disables the account of the specified service principal.
+
+### Example 2
+```powershell
+PS C:\> $attributes = @{
+    Engineering = @{
+        "@odata.type" = "#Microsoft.DirectoryServices.CustomSecurityAttributeValue"
+        "Project@odata.type" = "#Collection(String)"
+        Project = @("Baker","Cascade")
+    }
+}
+PS C:\> Set-AzureADMSServicePrincipal -Id 7d194b0c-bf17-40ff-9f7f-4b671de8dc20 -CustomSecurityAttributes $attributes
+```
+
+Assign a custom security attribute with a multi-string value to an application (service principal).
+
+- Attribute set: `Engineering`
+- Attribute: `Project`
+- Attribute data type: Collection of Strings
+- Attribute value: `("Baker","Cascade")`
+
+### Example 3
+```powershell
+PS C:\> $attributesUpdate = @{
+    Engineering = @{
+        "@odata.type" = "#Microsoft.DirectoryServices.CustomSecurityAttributeValue"
+        "Project@odata.type" = "#Collection(String)"
+        Project = @("Alpine","Baker")
+    }
+}
+PS C:\> Set-AzureADMSServicePrincipal -Id 7d194b0c-bf17-40ff-9f7f-4b671de8dc20 -CustomSecurityAttributes $attributesUpdate 
+```
+
+Update a custom security attribute with a multi-string value for an application (service principal).
+
+- Attribute set: `Engineering`
+- Attribute: `Project`
+- Attribute data type: Collection of Strings
+- Attribute value: `("Alpine","Baker")`
+
+## PARAMETERS
+
+### -AccountEnabled
+Indicates whether the account is enabled.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AppId
+Specifies the application ID.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AppRoleAssignmentRequired
+Indicates whether an application role assignment is required.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CustomSecurityAttributes
+Custom security attributes for the service principal.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DisplayName
+Specifies the display name.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ErrorUrl
+Specifies the error URL.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Homepage
+Specifies the home page.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Id
+Specifies the ID of a service principal in Azure AD.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -KeyCredentials
+Specifies key credentials.
+
+```yaml
+Type: System.Collections.Generic.List`1[Microsoft.Open.MSGraph.Model.MsKeyCredential]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LogoutUrl
+Specifies the logout URL.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MicrosoftFirstParty
+Indicates whether the service principal is for a Microsoft first-party app.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PasswordCredentials
+Specifies password credentials.
+
+```yaml
+Type: System.Collections.Generic.List`1[Microsoft.Open.MSGraph.Model.MsPasswordCredential]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PreferredTokenSigningKeyThumbprint
+Preferred token signing key thumbprint for the service principal.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PublisherName
+Specifies the publisher name.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ReplyUrls
+The URLs that user tokens are sent to for sign in with the associated application, or the redirect URIs that OAuth 2.0 authorization codes and access tokens are sent to for the associated application.
+
+```yaml
+Type: System.Collections.Generic.List`1[System.String]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SamlMetadataUrl
+@{Text=}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ServicePrincipalNames
+Specifies service principal names.
+
+```yaml
+Type: System.Collections.Generic.List`1[System.String]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Tags
+Specifies an array of tags.
+Note that if you intend for this service principal to show up in the All Applications list in the admin portal, you need to set this value to {WindowsAzureActiveDirectoryIntegratedApp}
+
+```yaml
+Type: System.Collections.Generic.List`1[System.String]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/azureadps-2.0-preview/AzureAD/Set-AzureADMSTrustFrameworkPolicy.md
+++ b/azureadps-2.0-preview/AzureAD/Set-AzureADMSTrustFrameworkPolicy.md
@@ -20,7 +20,7 @@ Set-AzureADMSTrustFrameworkPolicy [-Id <String>] [-OutputFilePath <String>] -Con
 
 ### File
 ```
-Set-AzureADMSTrustFrameworkPolicy [-Id <String>] -InputFilePath <String> [-OutputFilePath <String>]
+Set-AzureADMSTrustFrameworkPolicy -Id <String> -InputFilePath <String> [-OutputFilePath <String>]
  [<CommonParameters>]
 ```
 
@@ -94,7 +94,7 @@ Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: False
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/azureadps-2.0-preview/AzureAD/Set-AzureADMSUser.md
+++ b/azureadps-2.0-preview/AzureAD/Set-AzureADMSUser.md
@@ -1,0 +1,146 @@
+---
+external help file: Microsoft.Open.MS.GraphBeta.PowerShell.dll-Help.xml
+Module Name: AzureADPreview
+online version:
+schema: 2.0.0
+---
+
+# Set-AzureADMSUser
+
+## SYNOPSIS
+Updates a user.
+
+## SYNTAX
+
+```
+Set-AzureADMSUser -Id <String> [-DisplayName <String>] [-CustomSecurityAttributes <Object>]
+ [-UserPrincipalName <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Updates a user in Azure Active Directory (AD).
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> $user = Get-AzureADMSUser -UserPrincipalName TestUser@example.com 
+PS C:\> $user.DisplayName = 'YetAnotherTestUser' 
+PS C:\> Set-AzureADMSUser -UserPrincipalName TestUser@example.com -Displayname $user.Displayname
+```
+
+Update a user.
+
+### Example 2
+```powershell
+PS C:\> $attributes = @{
+    Engineering = @{
+        "@odata.type" = "#Microsoft.DirectoryServices.CustomSecurityAttributeValue"
+        "Project@odata.type" = "#Collection(String)"
+        Project = @("Baker","Cascade")
+    }
+} 
+PS C:\> Set-AzureADMSUser -Id dbb22700-a7de-4372-ae78-0098ee60e55e -CustomSecurityAttributes $attributes
+```
+
+Assign a custom security attribute with a multi-string value to a user.
+
+- Attribute set: `Engineering`
+- Attribute: `Project`
+- Attribute data type: Collection of Strings
+- Attribute value: `("Baker","Cascade")`
+
+### Example 3
+```powershell
+PS C:\> $attributesUpdate = @{
+    Engineering = @{
+        "@odata.type" = "#Microsoft.DirectoryServices.CustomSecurityAttributeValue"
+        "Project@odata.type" = "#Collection(String)"
+        Project = @("Alpine","Baker")
+    }
+}
+PS C:\> Set-AzureADMSUser -Id dbb22700-a7de-4372-ae78-0098ee60e55e -CustomSecurityAttributes $attributes
+```
+
+Update a custom security attribute with a multi-string value for a user.
+
+- Attribute set: `Engineering`
+- Attribute: `Project`
+- Attribute data type: Collection of Strings
+- Attribute value: `("Alpine","Baker")`
+
+## PARAMETERS
+
+### -CustomSecurityAttributes
+Custom security attributes for the user.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DisplayName
+Specifies the user's display name.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Id
+Specifies the ID of a user in Azure AD.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -UserPrincipalName
+Specifies the user principal name of a user in Azure AD.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/mapping/groupMapping-2.0-preview.json
+++ b/mapping/groupMapping-2.0-preview.json
@@ -257,5 +257,18 @@
     "Remove-AzureADMSScopedRoleMembership": "Administrative Units",		
     "Set-AzureADMSAdministrativeUnit": "Administrative Units",	
     "Remove-AzureADMSApplicationVerifiedPublisher": "Applications",		
-    "Set-AzureADMSApplicationVerifiedPublisher": "Applications"    
+    "Set-AzureADMSApplicationVerifiedPublisher": "Applications",
+    "Add-AzureADMScustomSecurityAttributeDefinitionAllowedValues": "Custom Security Attributes",  
+    "Get-AzureADMSAttributeSet": "Custom Security Attributes", 
+    "Get-AzureADMSCustomSecurityAttributeDefinition": "Custom Security Attributes", 
+    "Get-AzureADMSCustomSecurityAttributeDefinitionAllowedValue": "Custom Security Attributes", 
+    "New-AzureADMSAttributeSet": "Custom Security Attributes", 
+    "New-AzureADMSCustomSecurityAttributeDefinition": "Custom Security Attributes", 
+    "Set-AzureADMSAttributeSet": "Custom Security Attributes", 
+    "Set-AzureADMSCustomSecurityAttributeDefinition": "Custom Security Attributes", 
+    "Set-AzureADMSCustomSecurityAttributeDefinitionAllowedValue": "Custom Security Attributes", 
+    "Get-AzureADMSServicePrincipal": "Service Principals",
+    "Set-AzureADMSServicePrincipal": "Service Principals",
+    "Get-AzureADMSUser": "Users",
+    "Set-AzureADMSUser": "Users"
 }


### PR DESCRIPTION
Fixing whitespace between two options that was missing in Type parameter.