### PR TITLE
Fixing whitespace missing in Type parameter

### DIFF
--- a/azureadps-2.0-preview/AzureAD/Open-AzureADMSPrivilegedRoleAssignmentRequest.md
+++ b/azureadps-2.0-preview/AzureAD/Open-AzureADMSPrivilegedRoleAssignmentRequest.md
@@ -148,7 +148,7 @@ Accept wildcard characters: False
 
 ### -Type
 The request type.
-The value can be AdminAdd, UserAdd, AdminUpdate, AdminRemove, UserRemove, UserExtend, UserRenew, AdminRenewand AdminExtend.
+The value can be AdminAdd, UserAdd, AdminUpdate, AdminRemove, UserRemove, UserExtend, UserRenew, AdminRenew and AdminExtend.
 Required.
 
 ```yaml


### PR DESCRIPTION
Fixing whitespace between two options that was missing in Type parameter.