### PR TITLE
Patch 1 - Get-AzureADGroup vs Get-AzureADMSGroup

### DIFF
--- a/azureadps-2.0/AzureAD/Get-AzureADGroup.md
+++ b/azureadps-2.0/AzureAD/Get-AzureADGroup.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Get-AzureADGroup
 
 ## SYNOPSIS
-Gets a group.
+Gets a group (via AzureAD Graph).
 
 ## SYNTAX
 
@@ -28,7 +28,7 @@ Get-AzureADGroup -ObjectId <String> [-All <Boolean>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The Get-AzureADGroup cmdlet gets a group in Azure Active Directory (AD).
+The Get-AzureADGroup cmdlet gets a group in Azure Active Directory (AD) using the AzureAD Graph.
 
 ## EXAMPLES
 
@@ -158,6 +158,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
+This cmdlet uses the AzureAD Graph instead of the MSGraph. Commands that use the MSGraph are in the format of \*-ADMS\*. For more information on the naming convention see [New enhancements to the #AzureAD PowerShell 2.0 preview. Manage dynamic groups and more!](https://techcommunity.microsoft.com/t5/azure-active-directory-identity/new-enhancements-to-the-azuread-powershell-2-0-preview-manage/ba-p/245153)
+
 ## RELATED LINKS
 
 [New-AzureADGroup]()
@@ -165,4 +167,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Remove-AzureADGroup]()
 
 [Set-AzureADGroup]()
+
+[Get-AzureADMSGroup]()
 

--- a/azureadps-2.0/AzureAD/Get-AzureADMSGroup.md
+++ b/azureadps-2.0/AzureAD/Get-AzureADMSGroup.md
@@ -28,7 +28,7 @@ Get-AzureADMSGroup -Id <String> [-All <Boolean>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The Get-AzureADMSGroup cmdlet gets information about groups in Azure Active Directory (Azure AD) using he Microsoft Graph.
+The Get-AzureADMSGroup cmdlet gets information about groups in Azure Active Directory (Azure AD) using the Microsoft Graph.
 To get a group, specify the Id parameter. 
 Specify the SearchString or Filter parameter to find particular groups. 
 If you specify no parameters, this cmdlet gets all groups.

--- a/azureadps-2.0/AzureAD/Get-AzureADMSGroup.md
+++ b/azureadps-2.0/AzureAD/Get-AzureADMSGroup.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Get-AzureADMSGroup
 
 ## SYNOPSIS
-Gets information about groups in Azure AD.
+Gets information about groups in Azure AD (via MS Graph).
 
 ## SYNTAX
 
@@ -28,7 +28,7 @@ Get-AzureADMSGroup -Id <String> [-All <Boolean>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The Get-AzureADMSGroup cmdlet gets information about groups in Azure Active Directory (Azure AD).
+The Get-AzureADMSGroup cmdlet gets information about groups in Azure Active Directory (Azure AD) using he Microsoft Graph.
 To get a group, specify the Id parameter. 
 Specify the SearchString or Filter parameter to find particular groups. 
 If you specify no parameters, this cmdlet gets all groups.
@@ -179,6 +179,8 @@ Accept wildcard characters: False
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
+This cmdlet uses the MSGraph instead of the AzureAD Graph. Commands that use the MSGraph are in the format of \*-ADMS\*. For more information on the naming convention see [New enhancements to the #AzureAD PowerShell 2.0 preview. Manage dynamic groups and more!](https://techcommunity.microsoft.com/t5/azure-active-directory-identity/new-enhancements-to-the-azuread-powershell-2-0-preview-manage/ba-p/245153)
+
 ## INPUTS
 
 ### System.String
@@ -199,6 +201,8 @@ We recommend that you do not use this cmdlet in a production environment.
 [Remove-AzureADMSGroup]()
 
 [Set-AzureADMSGroup]()
+
+[Get-AzureADGroup]()
 
 [#AzureAD: Certificate based authentication for iOS and Android now in preview!](https://blogs.technet.microsoft.com/enterprisemobility/2016/07/18/azuread-certificate-based-authentication-for-ios-and-android-now-in-preview/)
 


### PR DESCRIPTION
Updated doco for Get-AzureADGroup vs Get-AzureADMSGroup with regards to using AzureAD Graph vs MSGraph. This took me a little time to figure out until I see the comments on [https://techcommunity.microsoft.com/t5/azure-active-directory-identity/new-enhancements-to-the-azuread-powershell-2-0-preview-manage/ba-p/245153](https://techcommunity.microsoft.com/t5/azure-active-directory-identity/new-enhancements-to-the-azuread-powershell-2-0-preview-manage/ba-p/245153]) and realised I wasn't the first person to get confused. 

[1st Comment](https://techcommunity.microsoft.com/t5/azure-active-directory-identity/new-enhancements-to-the-azuread-powershell-2-0-preview-manage/bc-p/1065088/highlight/true#M1813)
[2nd Comment](https://techcommunity.microsoft.com/t5/azure-active-directory-identity/new-enhancements-to-the-azuread-powershell-2-0-preview-manage/bc-p/2507340/highlight/true#M3592)

This may need to be done to all AD vs ADMS pages but at least this is start. 

PS: Also, not sure why there are two merged PR's in Patch-1 which is what I folked when I pressed 'Edit' from docs.microsoft.com. I'm guessing there is a patch-1 branch on the actual repo that may need to be deleted. 

