### PR TITLE
Update Reset-AzureADMSLifeCycleGroup.md

### DIFF
--- a/azureadps-2.0-preview/AzureAD/Reset-AzureADMSLifeCycleGroup.md
+++ b/azureadps-2.0-preview/AzureAD/Reset-AzureADMSLifeCycleGroup.md
@@ -13,7 +13,7 @@ Renews a group by updating the RenewedDateTime property on a group to the curren
 ## SYNTAX
 
 ```
-Reset-AzureADMSLifeCycleGroup -GroupId <String> [<CommonParameters>]
+Reset-AzureADMSLifeCycleGroup -Id <String> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -23,14 +23,14 @@ The Reset-AzureADMSLifeCycleGroup renews a group by updating the RenewedDateTime
 
 ### Example 1
 ```
-PS C:\> Reset-AzureADMSLifeCycleGroup -groupId cffd97bd-6b91-4c4e-b553-6918a320211c
+PS C:\> Reset-AzureADMSLifeCycleGroup -Id cffd97bd-6b91-4c4e-b553-6918a320211c
 ```
 
 The Reset-AzureADMSLifeCycleGroup renews a specified group by updating the RenewedDateTime property on a group to the current DateTime.
 
 ## PARAMETERS
 
-### -GroupId
+### -Id
 Specifies the ID of a group in Azure Active Directory.
 
 ```yaml


### PR DESCRIPTION

The example had an outdated syntax. It should be -Id and not -GroupId.

If you run it with GroupId, you get this error message:
Reset-AzureADMSLifeCycleGroup : A parameter cannot be found that matches parameter name 'GroupId'

(See also the command with the same name in the module AzureAD)