### PR TITLE
Update Get-AzureADServicePrincipal.md

### DIFF
--- a/azureadps-1.0/MSOnline/Get-MsolDirSyncFeatures.md
+++ b/azureadps-1.0/MSOnline/Get-MsolDirSyncFeatures.md
@@ -19,7 +19,7 @@ Get-MsolDirSyncFeatures [-Feature <String>] [-TenantId <Guid>] [<CommonParameter
 ```
 
 ## DESCRIPTION
-The **Get-MsolDirSyncProvisioningError** cmdlet gets the status of identity synchronization features for a tenant.
+The **Get-MsolDirSyncFeatures** cmdlet gets the status of identity synchronization features for a tenant.
 
 Synchronization features that can be used with this cmdlet include the following:
 

--- a/azureadps-2.0/AzureAD/Get-AzureADContact.md
+++ b/azureadps-2.0/AzureAD/Get-AzureADContact.md
@@ -38,6 +38,15 @@ b052db07-e7ec-4c0e-b481-a5ba550b9ee7 contact@contoso.com Contoso Contact
 
 This command retrieves all contact objects in the directory.
 
+### Example 2 Retrieve one contact using the filter parameter
+```
+PS C:\> Get-AzureADContact -All $true -Filter "mail -eq 'contact@contoso.com'"
+
+ObjectId                             Mail                DisplayName
+--------                             ----                -----------
+b052db07-e7ec-4c0e-b481-a5ba550b9ee7 contact@contoso.com Contoso Contact
+```
+
 ## PARAMETERS
 
 ### -All

--- a/azureadps-2.0/AzureAD/Get-AzureADServicePrincipal.md
+++ b/azureadps-2.0/AzureAD/Get-AzureADServicePrincipal.md
@@ -53,7 +53,7 @@ This command retrieves all service principal from the directory.
 ### Example 2: Retrieve a service principal by ID
 ```
 PS C:\> $ServicePrincipalId = (Get-AzureADServicePrincipal -Top 1).ObjectId
-PS C:\> Get-AzureADServicePrincipal $ServicePrincipalId
+PS C:\> Get-AzureADServicePrincipal -ObjectId $ServicePrincipalId
 
 ObjectId                             AppId                                DisplayName
 --------                             -----                                -----------


### PR DESCRIPTION
`ObjectId` is a named parameter and cannot be omitted.
Without the parameter name, it throws:
```
Get-AzureADServicePrincipal : A positional parameter cannot be found that accepts argument 'x'.
At line:1 char:1
+ Get-AzureADServicePrincipal $ServicePrincipalId
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Get-AzureADServicePrincipal], ParameterBindingException
    + FullyQualifiedErrorId : PositionalParameterNotFound,Microsoft.Open.AzureAD16.PowerShell.GetServicePrincipal
```