### PR TITLE
Update Get-AzureADServicePrincipal.md

### DIFF
--- a/azureadps-2.0/AzureAD/Get-AzureADServicePrincipal.md
+++ b/azureadps-2.0/AzureAD/Get-AzureADServicePrincipal.md
@@ -53,7 +53,7 @@ This command retrieves all service principal from the directory.
 ### Example 2: Retrieve a service principal by ID
 ```
 PS C:\> $ServicePrincipalId = (Get-AzureADServicePrincipal -Top 1).ObjectId
-PS C:\> Get-AzureADServicePrincipal $ServicePrincipalId
+PS C:\> Get-AzureADServicePrincipal -ObjectId $ServicePrincipalId
 
 ObjectId                             AppId                                DisplayName
 --------                             -----                                -----------


### PR DESCRIPTION
`ObjectId` is a named parameter and cannot be omitted.
Without the parameter name, it throws:
```
Get-AzureADServicePrincipal : A positional parameter cannot be found that accepts argument 'x'.
At line:1 char:1
+ Get-AzureADServicePrincipal $ServicePrincipalId
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Get-AzureADServicePrincipal], ParameterBindingException
    + FullyQualifiedErrorId : PositionalParameterNotFound,Microsoft.Open.AzureAD16.PowerShell.GetServicePrincipal
```