### PR TITLE
Add a more useful example to Add-AzureADApplicationOwner

### DIFF
--- a/azureadps-1.0/MSOnline/Set-MsolCompanySettings.md
+++ b/azureadps-1.0/MSOnline/Set-MsolCompanySettings.md
@@ -38,8 +38,7 @@ This command turns on the self-serve password reset feature for all administrato
 ## PARAMETERS
 
 ### -SelfServePasswordResetEnabled
-Indicates whether to allow the use of the self-service password reset feature.
-This setting is applied company-wide.
+Indicates whether to allow the use of the self-service password reset feature for all administrators in the company.
 
 ```yaml
 Type: Boolean

--- a/azureadps-2.0/AzureAD/Add-AzureADApplicationOwner.md
+++ b/azureadps-2.0/AzureAD/Add-AzureADApplicationOwner.md
@@ -22,9 +22,11 @@ The Add-AzureADApplicationOwner cmdlet adds an owner to an Azure Active Director
 
 ## EXAMPLES
 
-### Example 1: Add an owner to an application
+### Example 1: Add a user as an owner to an application
 ```
-PS C:\>Add-AzureADApplicationOwner -ObjectId 3ddd22e7-a150-4bb3-b100-e410dea1cb84 -RefObjectId c13dd34a-492b-4561-b171-40fcce2916c5
+PS C:\> $ApplicationId = (Get-AzureADApplication -Top 1).ObjectId
+PS C:\> $UserObjectId = (Get-AzureADUser -Top 1).ObjectId
+PS C:\> Add-AzureADApplicationOwner -ObjectId $ApplicationId -RefObjectId $UserObjectId
 ```
 
 This command adds an owner to an application.


### PR DESCRIPTION
Add a more practical example of how to use the `Add-AzureADApplicationOwner` similar to that seen in the examples for the `Add-AzureADServicePrincipalOwner` cmdlet