### PR TITLE
Boolean needs to be added to the -All Parameter

### DIFF
--- a/azureadps-2.0/AzureAD/Get-AzureADGroup.md
+++ b/azureadps-2.0/AzureAD/Get-AzureADGroup.md
@@ -34,7 +34,7 @@ The Get-AzureADGroup cmdlet gets a group in Azure Active Directory (AD) using th
 
 ### Example 1: Get all groups
 ```
-PS C:\>Get-AzureADGroup
+PS C:\>Get-AzureADGroup -All:$true
 
 
 ObjectId                             DisplayName                          Description


### PR DESCRIPTION
A boolean needs to be added to the -All parameter to return all groups, if this omitted an error is generated.