### PR TITLE
[BULK] Policheck update June 21 - country/region

### DIFF
--- a/azureadps-1.0/MSOnline/Get-MsolCompanyInformation.md
+++ b/azureadps-1.0/MSOnline/Get-MsolCompanyInformation.md
@@ -65,9 +65,9 @@ This cmdlet returns the following company level information:
 
 * CompanyType. What type of company this is (can be partner or regular tenant).
 
-* Country. The company's country.
+* Country. The company's country or region.
 
-* CountryLetterCode. The two letter code for the company's country.
+* CountryLetterCode. The two letter code for the company's country or region.
 
 * DapEnabled. For partners, whether or not this partner had delegated administrator privileges.
 

--- a/azureadps-1.0/MSOnline/Get-MsolContact.md
+++ b/azureadps-1.0/MSOnline/Get-MsolContact.md
@@ -160,7 +160,7 @@ This cmdlet returns contact objects, which include the following information:
 
 * City. The contact's city.
 
-* Country. The contact's country.
+* Country. The contact's country or region.
 
 * Department. The contact's department.
 

--- a/azureadps-1.0/MSOnline/Get-MsolUser.md
+++ b/azureadps-1.0/MSOnline/Get-MsolUser.md
@@ -124,7 +124,7 @@ Accept wildcard characters: False
 ```
 
 ### -Country
-Specifies the country to filter results on.
+Specifies the country or region to filter results on.
 
 ```yaml
 Type: String
@@ -367,8 +367,8 @@ Accept wildcard characters: False
 ```
 
 ### -UsageLocation
-Specifies the filter for the country where the services are consumed by the user.
-Specify a two-letter country code.
+Specifies the filter for the country or region where the services are consumed by the user.
+Specify a two-letter country or region code.
 
 ```yaml
 Type: String
@@ -413,7 +413,7 @@ This cmdlet returns user objects, which include the following information:
 
 * City. The user's city.
 
-* Country. The user's country.
+* Country. The user's country or region.
 
 * Department. The user's department.
 
@@ -475,8 +475,8 @@ Strong passwords are recommended.
 
 * Title. The user's title.
 
-* UsageLocation. The country where the services are consumed by the user.
-This must be a two letter country code.
+* UsageLocation. The country or region where the services are consumed by the user.
+This must be a two letter country or region code.
 
 * UserPrincipalName. The user ID of the user.
 

--- a/azureadps-1.0/MSOnline/New-MsolUser.md
+++ b/azureadps-1.0/MSOnline/New-MsolUser.md
@@ -124,7 +124,7 @@ Accept wildcard characters: False
 ```
 
 ### -Country
-Specifies the country of the user.
+Specifies the country or region of the user.
 
 ```yaml
 Type: String
@@ -487,7 +487,7 @@ Accept wildcard characters: False
 
 ### -UsageLocation
 Specifies the location of the user where services are consumed.
-Specify a two-letter country code.
+Specify a two-letter country or region code.
 
 ```yaml
 Type: String

--- a/azureadps-1.0/MSOnline/Set-MsolUser.md
+++ b/azureadps-1.0/MSOnline/Set-MsolUser.md
@@ -56,8 +56,8 @@ This command updates the display name for the specified user.
 PS C:\> Set-MsolUser -UserPrincipalName "davidchew@contoso.com" -UsageLocation "CA"
 ```
 
-This command sets the location country of a user.
-The country must be a two-letter ISO code.
+This command sets the location country or region of a user.
+The country or region must be a two-letter ISO code.
 This can be set for synced users as well as managed users.
 
 ### Example 4: Set the preferred data location
@@ -434,7 +434,7 @@ Accept wildcard characters: False
 
 ### -UsageLocation
 Specifies the location of the user where services are consumed.
-Specify a two-letter country code.
+Specify a two-letter country or region code.
 
 ```yaml
 Type: String

--- a/azureadps-2.0-preview/AzureAD/New-AzureADMSNamedLocationPolicy.md
+++ b/azureadps-2.0-preview/AzureAD/New-AzureADMSNamedLocationPolicy.md
@@ -44,9 +44,9 @@ PS C:\> $ipRanges = New-Object -TypeName Microsoft.Open.MSGraph.Model.IpRange
                                     }
 ```
 
-This command creates a new country named location policy in Azure AD.
+This command creates a new IP named location policy in Azure AD.
 
-### Example 2: Creates a new country named location policy in Azure AD.
+### Example 2: Creates a new country or region named location policy in Azure AD.
 ```
 PS C:\> New-AzureADMSNamedLocationPolicy -OdataType "#microsoft.graph.countryNamedLocation" -DisplayName "Country named location policy" -CountriesAndRegions "IN" -IncludeUnknownCountriesAndRegions $false
 
@@ -59,7 +59,7 @@ PS C:\> New-AzureADMSNamedLocationPolicy -OdataType "#microsoft.graph.countryNam
           IncludeUnknownCountriesAndRegions : False
 ```
 
-This command creates a new country named location policy in Azure AD.
+This command creates a new country or region named location policy in Azure AD.
 
 ## PARAMETERS
 

--- a/azureadps-2.0-preview/AzureAD/New-AzureADUser.md
+++ b/azureadps-2.0-preview/AzureAD/New-AzureADUser.md
@@ -78,7 +78,7 @@ Accept wildcard characters: False
 ```
 
 ### -Country
-Specifies the user's country.
+Specifies the user's country or region.
 
 ```yaml
 Type: String
@@ -450,8 +450,8 @@ Accept wildcard characters: False
 ```
 
 ### -UsageLocation
-A two letter country code (ISO standard 3166).
-Required for users that will be assigned licenses due to legal requirement to check for availability of services in countries.
+A two letter country or region code (ISO standard 3166).
+Required for users that will be assigned licenses due to legal requirement to check for availability of services in countries and regions.
 Examples include: "US", "JP", and "GB".
 
 ```yaml

--- a/azureadps-2.0-preview/AzureAD/Set-AzureADMSAdministrativeUnit.md
+++ b/azureadps-2.0-preview/AzureAD/Set-AzureADMSAdministrativeUnit.md
@@ -29,7 +29,7 @@ The Set-AzureADMSAdministrativeUnit cmdlet updates an administrative unit in Azu
 PS C:\> Set-AzureADMSAdministrativeUnit -Id $adminUnit.Id -MembershipType "Dynamic" -MembershipRuleProcessingState "On" -MembershipRule '(user.country -eq "United States")'
 ```
 
-Given an existing administrative unit referenced by $adminUnit, sets the membership type to dynamic and creates a membership rule to include all users whose country is equal to United States.
+Given an existing administrative unit referenced by $adminUnit, sets the membership type to dynamic and creates a membership rule to include all users whose country or region is equal to United States.
 
 ## PARAMETERS
 

--- a/azureadps-2.0-preview/AzureAD/Set-AzureADMSNamedLocationPolicy.md
+++ b/azureadps-2.0-preview/AzureAD/Set-AzureADMSNamedLocationPolicy.md
@@ -33,12 +33,12 @@ PS C:\> Set-AzureADMSNamedLocationPolicy -PolicyId 07a1f48d-0cbb-4c2c-8ea2-1ea00
 
 This command updates an ip named location policy in Azure AD by PolicyId.
 
-### Example 2: Update a country named location policy in Azure AD by PolicyId.
+### Example 2: Update a country or region named location policy in Azure AD by PolicyId.
 ```
 PS C:\> Set-AzureADMSNamedLocationPolicy -PolicyId 76fdfd4d-bd80-4c1e-8fd4-6abf49d121fe -OdataType "#microsoft.graph.countryNamedLocation" -IncludeUnknownCountriesAndRegions $true
 ```
 
-This command updates a country named location policy in Azure AD by PolicyId.
+This command updates a country or region named location policy in Azure AD by PolicyId.
 
 ## PARAMETERS
 

--- a/azureadps-2.0-preview/AzureAD/Set-AzureADUser.md
+++ b/azureadps-2.0-preview/AzureAD/Set-AzureADUser.md
@@ -77,7 +77,7 @@ Accept wildcard characters: False
 ```
 
 ### -Country
-Specifies the user's country.
+Specifies the user's country or region.
 
 ```yaml
 Type: String

--- a/azureadps-2.0/AzureAD/New-AzureADMSNamedLocationPolicy.md
+++ b/azureadps-2.0/AzureAD/New-AzureADMSNamedLocationPolicy.md
@@ -47,9 +47,9 @@ PS C:\> $ipRanges = New-Object -TypeName Microsoft.Open.MSGraph.Model.IpRange
                                     }
 ```
 
-This command creates a new country named location policy in Azure AD.
+This command creates a new IP named location policy in Azure AD.
 
-### Example 2: Creates a new country named location policy in Azure AD.
+### Example 2: Creates a new country or region named location policy in Azure AD.
 ```
 PS C:\> New-AzureADMSNamedLocationPolicy -OdataType "#microsoft.graph.countryNamedLocation" -DisplayName "Country named location policy" -CountriesAndRegions "IN" -IncludeUnknownCountriesAndRegions $false
 
@@ -62,7 +62,7 @@ PS C:\> New-AzureADMSNamedLocationPolicy -OdataType "#microsoft.graph.countryNam
           IncludeUnknownCountriesAndRegions : False
 ```
 
-This command creates a new country named location policy in Azure AD.
+This command creates a new country or region named location policy in Azure AD.
 
 ## PARAMETERS
 

--- a/azureadps-2.0/AzureAD/New-AzureADMSNamedLocationPolicy.yml
+++ b/azureadps-2.0/AzureAD/New-AzureADMSNamedLocationPolicy.yml
@@ -31,9 +31,9 @@ examples:
                                           }
                                         }
   description: |-
-    This command creates a new country named location policy in Azure AD.
+    This command creates a new IP named location policy in Azure AD.
   summary: ""
-- title: 'Example 2: Creates a new country named location policy in Azure AD.'
+- title: 'Example 2: Creates a new country or region named location policy in Azure AD.'
   code: |-
     PS C:\> New-AzureADMSNamedLocationPolicy -OdataType "#microsoft.graph.countryNamedLocation" -DisplayName "Country named location policy" -CountriesAndRegions "IN" -IncludeUnknownCountriesAndRegions $false
 
@@ -45,7 +45,7 @@ examples:
               CountriesAndRegions               : {IN}
               IncludeUnknownCountriesAndRegions : False
   description: |-
-    This command creates a new country named location policy in Azure AD.
+    This command creates a new country or region named location policy in Azure AD.
   summary: ""
 parameters:
 - type: <xref href="System.Collections.Generic.List`1" data-throw-if-not-resolved="False" /><span>[</span><xref href="Microsoft.Open.MSGraph.Model.CountriesAndRegion" data-throw-if-not-resolved="False" /><span>]</span>

--- a/azureadps-2.0/AzureAD/New-AzureADUser.md
+++ b/azureadps-2.0/AzureAD/New-AzureADUser.md
@@ -81,7 +81,7 @@ Accept wildcard characters: False
 
 ### -Country
 
-Specifies the user's country.
+Specifies the user's country or region.
 
 ```yaml
 Type: String
@@ -480,9 +480,9 @@ Accept wildcard characters: False
 
 ### -UsageLocation
 
-A two letter country code (ISO standard 3166).
+A two letter country or region code (ISO standard 3166).
 
-It's required for users that will be assigned licenses due to legal requirements to check for availability of services in countries.
+It's required for users that will be assigned licenses due to legal requirements to check for availability of services in countries and regions.
 Examples include: `US`, `JP`, and `GB`.
 
 ```yaml

--- a/azureadps-2.0/AzureAD/New-AzureADUser.yml
+++ b/azureadps-2.0/AzureAD/New-AzureADUser.yml
@@ -89,7 +89,7 @@ parameters:
 - type: <xref href="String" data-throw-if-not-resolved="False" />
   name: Country
   description: |+
-    Specifies the user's country.
+    Specifies the user's country or region.
 
   defaultValue: None
   position: Named
@@ -334,8 +334,8 @@ parameters:
 - type: <xref href="String" data-throw-if-not-resolved="False" />
   name: UsageLocation
   description: |+
-    A two letter country code (ISO standard 3166).
-    Required for users that will be assigned licenses due to legal requirement to check for availability of services in countries.
+    A two letter country or region code (ISO standard 3166).
+    Required for users that will be assigned licenses due to legal requirement to check for availability of services in countries and regions.
     Examples include: "US", "JP", and "GB".
 
   defaultValue: None

--- a/azureadps-2.0/AzureAD/Set-AzureADMSNamedLocationPolicy.md
+++ b/azureadps-2.0/AzureAD/Set-AzureADMSNamedLocationPolicy.md
@@ -33,12 +33,12 @@ PS C:\> Set-AzureADMSNamedLocationPolicy -PolicyId 07a1f48d-0cbb-4c2c-8ea2-1ea00
 
 This command updates an ip named location policy in Azure AD by PolicyId.
 
-### Example 2: Update a country named location policy in Azure AD by PolicyId.
+### Example 2: Update a country or region named location policy in Azure AD by PolicyId.
 ```
 PS C:\> Set-AzureADMSNamedLocationPolicy -PolicyId 76fdfd4d-bd80-4c1e-8fd4-6abf49d121fe -OdataType "#microsoft.graph.countryNamedLocation" -IncludeUnknownCountriesAndRegions $true
 ```
 
-This command updates a country named location policy in Azure AD by PolicyId.
+This command updates a country or region named location policy in Azure AD by PolicyId.
 
 ## PARAMETERS
 

--- a/azureadps-2.0/AzureAD/Set-AzureADMSNamedLocationPolicy.yml
+++ b/azureadps-2.0/AzureAD/Set-AzureADMSNamedLocationPolicy.yml
@@ -21,11 +21,11 @@ examples:
   description: |-
     This command updates an ip named location policy in Azure AD by PolicyId.
   summary: ""
-- title: 'Example 2: Update a country named location policy in Azure AD by PolicyId.'
+- title: 'Example 2: Update a country or region named location policy in Azure AD by PolicyId.'
   code: |-
     PS C:\> Set-AzureADMSNamedLocationPolicy -PolicyId 76fdfd4d-bd80-4c1e-8fd4-6abf49d121fe -OdataType "#microsoft.graph.countryNamedLocation" -IncludeUnknownCountriesAndRegions $true
   description: |-
-    This command updates a country named location policy in Azure AD by PolicyId.
+    This command updates a country or region named location policy in Azure AD by PolicyId.
   summary: ""
 parameters:
 - type: <xref href="System.Collections.Generic.List`1" data-throw-if-not-resolved="False" /><span>[</span><xref href="Microsoft.Open.MSGraph.Model.CountriesAndRegion" data-throw-if-not-resolved="False" /><span>]</span>

--- a/azureadps-2.0/AzureAD/Set-AzureADUser.md
+++ b/azureadps-2.0/AzureAD/Set-AzureADUser.md
@@ -89,7 +89,7 @@ Accept wildcard characters: False
 
 ### -Country
 
-Specifies the user's country.
+Specifies the user's country or region.
 
 ```yaml
 Type: String
@@ -476,7 +476,7 @@ Accept wildcard characters: False
 
 ### -UsageLocation
 
-A two letter country code ([ISO standard 3166](https://www.iso.org/iso-3166-country-codes.html)). Required for users that will be assigned licenses due to legal requirement to check for availability of services in countries.  Examples include: "US", "JP", and "GB". Not nullable.
+A two letter country or region code ([ISO standard 3166](https://www.iso.org/iso-3166-country-codes.html)). Required for users that will be assigned licenses due to legal requirement to check for availability of services in countries and regions.  Examples include: "US", "JP", and "GB". Not nullable.
 
 ```yaml
 Type: String

--- a/azureadps-2.0/AzureAD/Set-AzureADUser.yml
+++ b/azureadps-2.0/AzureAD/Set-AzureADUser.yml
@@ -102,7 +102,7 @@ parameters:
 - type: <xref href="String" data-throw-if-not-resolved="False" />
   name: Country
   description: |+
-    Specifies the user's country.
+    Specifies the user's country or region.
 
   defaultValue: None
   position: Named
@@ -332,7 +332,7 @@ parameters:
 - type: <xref href="String" data-throw-if-not-resolved="False" />
   name: UsageLocation
   description: |+
-    A two letter country code ([ISO standard 3166](https://www.iso.org/iso-3166-country-codes.html)). Required for users that will be assigned licenses due to legal requirement to check for availability of services in countries.  Examples include: "US", "JP", and "GB". Not nullable.
+    A two letter country or region code ([ISO standard 3166](https://www.iso.org/iso-3166-country-codes.html)). Required for users that will be assigned licenses due to legal requirement to check for availability of services in countries and regions.  Examples include: "US", "JP", and "GB". Not nullable.
 
   defaultValue: None
   position: Named


### PR DESCRIPTION
Fixes or partially addresses the following Policheck bugs (instances in code can't be changed):

- [100404](https://dev.azure.com/msft-skilling/learn-platform-policheck/_workitems/edit/100404)
- [100398](https://dev.azure.com/msft-skilling/learn-platform-policheck/_workitems/edit/100398)
- [100410](https://dev.azure.com/msft-skilling/learn-platform-policheck/_workitems/edit/100410)
- [100419](https://dev.azure.com/msft-skilling/learn-platform-policheck/_workitems/edit/100419)
- [100412](https://dev.azure.com/msft-skilling/learn-platform-policheck/_workitems/edit/100412)
- [100417](https://dev.azure.com/msft-skilling/learn-platform-policheck/_workitems/edit/100417)
- [100424](https://dev.azure.com/msft-skilling/learn-platform-policheck/_workitems/edit/100424)
- [100414](https://dev.azure.com/msft-skilling/learn-platform-policheck/_workitems/edit/100414)
- [100422](https://dev.azure.com/msft-skilling/learn-platform-policheck/_workitems/edit/100422)
- [100409](https://dev.azure.com/msft-skilling/learn-platform-policheck/_workitems/edit/100409)
- [100420](https://dev.azure.com/msft-skilling/learn-platform-policheck/_workitems/edit/100420)
- [100395](https://dev.azure.com/msft-skilling/learn-platform-policheck/_workitems/edit/100395)
- [100416](https://dev.azure.com/msft-skilling/learn-platform-policheck/_workitems/edit/100416)
- [100415](https://dev.azure.com/msft-skilling/learn-platform-policheck/_workitems/edit/100415)
- [100401](https://dev.azure.com/msft-skilling/learn-platform-policheck/_workitems/edit/100401)
- [100421](https://dev.azure.com/msft-skilling/learn-platform-policheck/_workitems/edit/100421)

Also corrects several instances of "This command creates a new **country** named location policy in Azure AD" to "This command creates a new **IP** named location policy in Azure AD." The incorrect sentence was a duplicate of another sentence in the article. Rather than add "or region" to the incorrect sentence I corrected it.