### PR TITLE
Fix SigningCertificateUpdateStatus of Set-MsolDomainAuthentication.md

### DIFF
--- a/azureadps-1.0/MSOnline/Set-MsolDomainAuthentication.md
+++ b/azureadps-1.0/MSOnline/Set-MsolDomainAuthentication.md
@@ -20,8 +20,7 @@ Set-MsolDomainAuthentication -DomainName <String> -Authentication <DomainAuthent
  [-PassiveLogOnUri <String>] [-ActiveLogOnUri <String>] [-IssuerUri <String>] [-FederationBrandName <String>]
  [-MetadataExchangeUri <String>] [-PreferredAuthenticationProtocol <AuthenticationProtocol>]
  [-SupportsMfa <Boolean>] [-DefaultInteractiveAuthenticationMethod <String>]
- [-OpenIdConnectDiscoveryEndpoint <String>] [-SigningCertificate
- Status <SigningCertificateUpdateStatus>]
+ [-OpenIdConnectDiscoveryEndpoint <String>] [-SigningCertificateUpdateStatus <SigningCertificateUpdateStatus>]
  [-PromptLoginBehavior <PromptLoginBehavior>] [-TenantId <Guid>] [<CommonParameters>]
 ```
 


### PR DESCRIPTION
Looks like this attribute was split in two by a line return then further mangled.
Proof that this attribute exists, just below in the same doc: https://github.com/Azure/azure-docs-powershell-azuread/blob/c3ec76455c2eedc9b73b7f2f2ccfcc2c59a51a9e/azureadps-1.0/MSOnline/Set-MsolDomainAuthentication.md?plain=1#L285