### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs (part 6)

### DIFF
--- a/azureadps-2.0-preview/AzureAD/Get-AzureADUserMembership.yml
+++ b/azureadps-2.0-preview/AzureAD/Get-AzureADUserMembership.yml
@@ -8,7 +8,7 @@ syntaxes:
 examples:
 - title: 'Example 1: Get user memberships'
   code: |-
-    PS C:\>Get-AzureADUserMembership  -ObjectId "df19e8e6-2ad7-453e-87f5-037f6529ae16"
+    PS C:\>Get-AzureADUserMembership  -ObjectId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
 
     ObjectId                             ObjectType
     --------                             ----------

--- a/azureadps-2.0-preview/AzureAD/Get-AzureADUserOwnedDevice.md
+++ b/azureadps-2.0-preview/AzureAD/Get-AzureADUserOwnedDevice.md
@@ -26,7 +26,7 @@ The **Get-AzureADUserOwnedDevice** cmdlet gets registered devices owned by the s
 
 ### Example 1: Get devices owned by a user
 ```
-PS C:\>Get-AzureADUserOwnedDevice -ObjectId "df19e8e6-2ad7-453e-87f5-037f6529ae16"
+PS C:\>Get-AzureADUserOwnedDevice -ObjectId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
 ```
 
 This command gets the registered devices owned by the specified user.

--- a/azureadps-2.0-preview/AzureAD/Get-AzureADUserOwnedDevice.yml
+++ b/azureadps-2.0-preview/AzureAD/Get-AzureADUserOwnedDevice.yml
@@ -8,7 +8,7 @@ syntaxes:
 examples:
 - title: 'Example 1: Get devices owned by a user'
   code: |-
-    PS C:\>Get-AzureADUserOwnedDevice -ObjectId "df19e8e6-2ad7-453e-87f5-037f6529ae16"
+    PS C:\>Get-AzureADUserOwnedDevice -ObjectId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
   description: |-
     This command gets the registered devices owned by the specified user.
   summary: ""

--- a/azureadps-2.0-preview/AzureAD/Get-AzureADUserOwnedObject.md
+++ b/azureadps-2.0-preview/AzureAD/Get-AzureADUserOwnedObject.md
@@ -26,7 +26,7 @@ The **Get-AzureADUserOwnedObject** cmdlet gets objects owned by a user in Azure 
 
 ### Example 1: Get objects owned by a user
 ```
-PS C:\>Get-AzureADUserOwnedObject -ObjectId "df19e8e6-2ad7-453e-87f5-037f6529ae16"
+PS C:\>Get-AzureADUserOwnedObject -ObjectId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
 
 ObjectId                             ObjectType
 --------                             ----------

--- a/azureadps-2.0-preview/AzureAD/Get-AzureADUserOwnedObject.yml
+++ b/azureadps-2.0-preview/AzureAD/Get-AzureADUserOwnedObject.yml
@@ -8,7 +8,7 @@ syntaxes:
 examples:
 - title: 'Example 1: Get objects owned by a user'
   code: |-
-    PS C:\>Get-AzureADUserOwnedObject -ObjectId "df19e8e6-2ad7-453e-87f5-037f6529ae16"
+    PS C:\>Get-AzureADUserOwnedObject -ObjectId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
 
     ObjectId                             ObjectType
     --------                             ----------

--- a/azureadps-2.0-preview/AzureAD/Get-AzureADUserRegisteredDevice.md
+++ b/azureadps-2.0-preview/AzureAD/Get-AzureADUserRegisteredDevice.md
@@ -26,7 +26,7 @@ The **Get-AzureADUserRegisteredDevice** cmdlet gets devices registered by a user
 
 ### Example 1: Get registered devices
 ```
-PS C:\>Get-AzureADUserRegisteredDevice -ObjectId  "df19e8e6-2ad7-453e-87f5-037f6529ae16"
+PS C:\>Get-AzureADUserRegisteredDevice -ObjectId  "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
 ```
 
 This command gets the devices that are registered to the specified user.

--- a/azureadps-2.0-preview/AzureAD/Get-AzureADUserRegisteredDevice.yml
+++ b/azureadps-2.0-preview/AzureAD/Get-AzureADUserRegisteredDevice.yml
@@ -8,7 +8,7 @@ syntaxes:
 examples:
 - title: 'Example 1: Get registered devices'
   code: |-
-    PS C:\>Get-AzureADUserRegisteredDevice -ObjectId  "df19e8e6-2ad7-453e-87f5-037f6529ae16"
+    PS C:\>Get-AzureADUserRegisteredDevice -ObjectId  "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
   description: |-
     This command gets the devices that are registered to the specified user.
   summary: ""

--- a/azureadps-2.0-preview/AzureAD/Get-AzureADUserThumbnailPhoto.md
+++ b/azureadps-2.0-preview/AzureAD/Get-AzureADUserThumbnailPhoto.md
@@ -26,7 +26,7 @@ Retrieve the thumbnail photo of a user
 
 ### Example 1
 ```
-PS C:\WINDOWS\system32> Get-AzureADUserThumbnailPhoto -ObjectId df19e8e6-2ad7-453e-87f5-037f6529ae16
+PS C:\WINDOWS\system32> Get-AzureADUserThumbnailPhoto -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
 
 
 Tag                  :

--- a/azureadps-2.0-preview/AzureAD/Get-AzureADUserThumbnailPhoto.yml
+++ b/azureadps-2.0-preview/AzureAD/Get-AzureADUserThumbnailPhoto.yml
@@ -18,7 +18,7 @@ syntaxes:
 examples:
 - title: Example 1
   code: |-
-    PS C:\WINDOWS\system32> Get-AzureADUserThumbnailPhoto -ObjectId df19e8e6-2ad7-453e-87f5-037f6529ae16
+    PS C:\WINDOWS\system32> Get-AzureADUserThumbnailPhoto -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
 
 
     Tag                  :

--- a/azureadps-2.0-preview/AzureAD/New-AzureADApplicationExtensionProperty.md
+++ b/azureadps-2.0-preview/AzureAD/New-AzureADApplicationExtensionProperty.md
@@ -28,12 +28,12 @@ The **New-AzureADApplicationExtensionProperty** cmdlet creates an application ex
 
 ### Example 1: Create an extension property
 ```
-PS C:\>New-AzureADApplicationExtensionProperty -ObjectID "3ddd22e7-a150-4bb3-b100-e410dea1cb84" -DataType "string" -Name "NewAttribute"
+PS C:\>New-AzureADApplicationExtensionProperty -ObjectID "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -DataType "string" -Name "NewAttribute"
 
 
 ObjectId                             Name                                                    TargetObjects
 --------                             ----                                                    -------------
-3ddd22e7-a150-4bb3-b100-e410dea1cb84 extension_36ee4c6c081240a2b820b22ebd02bce3_NewAttribute {}
+aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb extension_36ee4c6c081240a2b820b22ebd02bce3_NewAttribute {}
 ```
 
 This command creates an application extension property of the string type for the specified object.

--- a/azureadps-2.0-preview/AzureAD/New-AzureADApplicationExtensionProperty.yml
+++ b/azureadps-2.0-preview/AzureAD/New-AzureADApplicationExtensionProperty.yml
@@ -18,12 +18,12 @@ syntaxes:
 examples:
 - title: 'Example 1: Create an extension property'
   code: |-
-    PS C:\>New-AzureADApplicationExtensionProperty -ObjectID "3ddd22e7-a150-4bb3-b100-e410dea1cb84" -DataType "string" -Name "NewAttribute"
+    PS C:\>New-AzureADApplicationExtensionProperty -ObjectID "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -DataType "string" -Name "NewAttribute"
 
 
     ObjectId                             Name                                                    TargetObjects
     --------                             ----                                                    -------------
-    3ddd22e7-a150-4bb3-b100-e410dea1cb84 extension_36ee4c6c081240a2b820b22ebd02bce3_NewAttribute {}
+    aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb extension_36ee4c6c081240a2b820b22ebd02bce3_NewAttribute {}
   description: |-
     This command creates an application extension property of the string type for the specified object.
   summary: ""

--- a/azureadps-2.0-preview/AzureAD/New-AzureADApplicationKeyCredential.md
+++ b/azureadps-2.0-preview/AzureAD/New-AzureADApplicationKeyCredential.md
@@ -33,7 +33,7 @@ PS C:\> New-AzureADApplicationKeyCredential -ObjectId $AppId -CustomKeyIdentifie
 
 CustomKeyIdentifier : {84, 101, 115, 116}
 EndDate             : 11/7/2017 12:00:00 AM
-KeyId               : a5845538-3f67-402d-a03e-36d768f1441e
+KeyId               : aaaaaaaa-0b0b-1c1c-2d2d-333333333333
 StartDate           : 11/7/2016 12:00:00 AM
 Type                : Symmetric
 Usage               : Sign
@@ -54,7 +54,7 @@ PS C:\> $base64Value = [System.Convert]::ToBase64String($bin)
 PS C:\> $bin = $cer.GetCertHash()
 PS C:\> $base64Thumbprint = [System.Convert]::ToBase64String($bin)
 PS C:\> $keyid = [System.Guid]::NewGuid().ToString() 
-PS C:\> New-AzureADApplicationKeyCredential -ObjectId 009d786a-3503-4217-b8ab-db03d71c179a -CustomKeyIdentifier $base64Thumbprint -Type AsymmetricX509Cert -Usage Verify -Value $base64Value -StartDate $cer.GetEffectiveDateString() -EndDate $cer.GetExpirationDateString()
+PS C:\> New-AzureADApplicationKeyCredential -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb -CustomKeyIdentifier $base64Thumbprint -Type AsymmetricX509Cert -Usage Verify -Value $base64Value -StartDate $cer.GetEffectiveDateString() -EndDate $cer.GetExpirationDateString()
 ```
 
 The first seven commands create values for the application key credential and stores them in variables.

--- a/azureadps-2.0-preview/AzureAD/New-AzureADApplicationKeyCredential.yml
+++ b/azureadps-2.0-preview/AzureAD/New-AzureADApplicationKeyCredential.yml
@@ -27,7 +27,7 @@ examples:
 
     CustomKeyIdentifier : {84, 101, 115, 116}
     EndDate             : 11/7/2017 12:00:00 AM
-    KeyId               : a5845538-3f67-402d-a03e-36d768f1441e
+    KeyId               : aaaaaaaa-0b0b-1c1c-2d2d-333333333333
     StartDate           : 11/7/2016 12:00:00 AM
     Type                : Symmetric
     Usage               : Sign
@@ -47,7 +47,7 @@ examples:
     PS C:\> $bin = $cer.GetCertHash()
     PS C:\> $base64Thumbprint = [System.Convert]::ToBase64String($bin)
     PS C:\> $keyid = [System.Guid]::NewGuid().ToString() 
-    PS C:\> New-AzureADApplicationKeyCredential -ObjectId 009d786a-3503-4217-b8ab-db03d71c179a -CustomKeyIdentifier $base64Thumbprint -Type AsymmetricX509Cert -Usage Verify -Value $base64Value -StartDate $cer.GetEffectiveDateString() -EndDate $cer.GetExpirationDateString()
+    PS C:\> New-AzureADApplicationKeyCredential -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb -CustomKeyIdentifier $base64Thumbprint -Type AsymmetricX509Cert -Usage Verify -Value $base64Value -StartDate $cer.GetEffectiveDateString() -EndDate $cer.GetExpirationDateString()
   description: |-
     The first seven commands create values for the application key credential and stores them in variables.
 

--- a/azureadps-2.0-preview/AzureAD/New-AzureADApplicationPasswordCredential.md
+++ b/azureadps-2.0-preview/AzureAD/New-AzureADApplicationPasswordCredential.md
@@ -28,7 +28,7 @@ The **New-AzureADApplicationPasswordCredential** cmdlet creates a password crede
 
 ### Example 1: Create a password credential
 ```
-PS C:\>New-AzureADApplicationPasswordCredential -ObjectId "3ddd22e7-a150-4bb3-b100-e410dea1cb84"
+PS C:\>New-AzureADApplicationPasswordCredential -ObjectId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
 
 CustomKeyIdentifier :
 EndDate             : 9/28/2017 3:57:10 PM
@@ -157,5 +157,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Get-AzureADApplicationPasswordCredential](./Get-AzureADApplicationPasswordCredential.md)
 
 [Remove-AzureADApplicationPasswordCredential](./Remove-AzureADApplicationPasswordCredential.md)
-
-

--- a/azureadps-2.0-preview/AzureAD/New-AzureADApplicationPasswordCredential.yml
+++ b/azureadps-2.0-preview/AzureAD/New-AzureADApplicationPasswordCredential.yml
@@ -18,7 +18,7 @@ syntaxes:
 examples:
 - title: 'Example 1: Create a password credential'
   code: |-
-    PS C:\>New-AzureADApplicationPasswordCredential -ObjectId "3ddd22e7-a150-4bb3-b100-e410dea1cb84"
+    PS C:\>New-AzureADApplicationPasswordCredential -ObjectId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
 
     CustomKeyIdentifier :
     EndDate             : 9/28/2017 3:57:10 PM

--- a/azureadps-2.0-preview/AzureAD/New-AzureADMSApplication.md
+++ b/azureadps-2.0-preview/AzureAD/New-AzureADMSApplication.md
@@ -55,14 +55,14 @@ PS C:\>New-AzureADMSApplication `
           -InformationalUrl @{ SupportUrl = "https://mynewapp.contoso.com/support.html" } `
           -IsDeviceOnlyAuthSupported $false `
           -IsFallbackPublicClient $false `
-          -KeyCredentials @{ KeyId = "11111111-1111-1111-1111-111111111111"; Usage = "Encrypt"; Key = {cert}; Type = "AsymmetricX509Cert" } `
+          -KeyCredentials @{ KeyId = "aaaaaaaa-0b0b-1c1c-2d2d-333333333333"; Usage = "Encrypt"; Key = {cert}; Type = "AsymmetricX509Cert" } `
           -OptionalClaims @{ IdToken = [PSCustomObject]@{ Name = "claimName"; Source = "claimSource" } } `
           -ParentalControlSettings @{ LegalAgeGroupRule = "Block" } `
           -PublicClient @{ RedirectUris = "https://mynewapp.contoso.com/" } `
           -RequiredResourceAccess @{ ResourceAppId = "31111111-1111-1111-1111-111111111111"; ResourceAccess = [PSCustomObject]@{ Type = "Scope" } } `
           -SignInAudience AzureADandPersonalMicrosoftAccount `
           -Tags "mytag" `
-          -TokenEncryptionKeyId "11111111-1111-1111-1111-111111111111" `
+          -TokenEncryptionKeyId "aaaaaaaa-0b0b-1c1c-2d2d-333333333333" `
           -Web @{ LogoutUrl = "https://mynewapp.contoso.com/logout.html" } `
           -GroupMembershipClaims "SecurityGroup" `
           -OrgRestrictions {orgrestrictions}
@@ -87,7 +87,7 @@ PS C:\>New-AzureADMSApplication `
           ResourceSpecificApplicationPermissions:
           }
 
-          AppId                     : 4095dbc0-2095-42d3-b631-7a48eeede86c
+          AppId                     : 00001111-aaaa-2222-bbbb-3333cccc4444
           ApplicationTemplateId     :
           AppRoles                  : {class AppRole {
           AllowedMemberTypes: System.Collections.Generic.List`1[System.String]
@@ -118,7 +118,7 @@ PS C:\>New-AzureADMSApplication `
           CustomKeyIdentifier: System.Byte[]
           DisplayName:
           EndDateTime:
-          KeyId: 11111111-1111-1111-1111-111111111111
+          KeyId: aaaaaaaa-0b0b-1c1c-2d2d-333333333333
           StartDateTime:
           Type: AsymmetricX509Cert
           Usage: Encrypt
@@ -151,7 +151,7 @@ PS C:\>New-AzureADMSApplication `
           }
           SignInAudience            : AzureADandPersonalMicrosoftAccount
           Tags                      : {mytag}
-          TokenEncryptionKeyId      : 11111111-1111-1111-1111-111111111111
+          TokenEncryptionKeyId      : aaaaaaaa-0b0b-1c1c-2d2d-333333333333
           Web                       : class WebApplication {
           HomePageUrl:
           LogoutUrl: https://mynewapp.contoso.com/logout.html
@@ -545,4 +545,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Remove-AzureADMSApplication]()
 
 [Set-AzureADMSApplication]()
-

--- a/azureadps-2.0-preview/AzureAD/New-AzureADMSApplication.yml
+++ b/azureadps-2.0-preview/AzureAD/New-AzureADMSApplication.yml
@@ -89,14 +89,14 @@ examples:
               -InformationalUrl @{ SupportUrl = "https://mynewapp.contoso.com/support.html" } `
               -IsDeviceOnlyAuthSupported $false `
               -IsFallbackPublicClient $false `
-              -KeyCredentials @{ KeyId = "11111111-1111-1111-1111-111111111111"; Usage = "Encrypt"; Key = {cert}; Type = "AsymmetricX509Cert" } `
+              -KeyCredentials @{ KeyId = "aaaaaaaa-0b0b-1c1c-2d2d-333333333333"; Usage = "Encrypt"; Key = {cert}; Type = "AsymmetricX509Cert" } `
               -OptionalClaims @{ IdToken = [PSCustomObject]@{ Name = "claimName"; Source = "claimSource" } } `
               -ParentalControlSettings @{ LegalAgeGroupRule = "Block" } `
               -PublicClient @{ RedirectUris = "https://mynewapp.contoso.com/" } `
               -RequiredResourceAccess @{ ResourceAppId = "31111111-1111-1111-1111-111111111111"; ResourceAccess = [PSCustomObject]@{ Type = "Scope" } } `
               -SignInAudience AzureADandPersonalMicrosoftAccount `
               -Tags "mytag" `
-              -TokenEncryptionKeyId "11111111-1111-1111-1111-111111111111" `
+              -TokenEncryptionKeyId "aaaaaaaa-0b0b-1c1c-2d2d-333333333333" `
               -Web @{ LogoutUrl = "https://mynewapp.contoso.com/logout.html" } `
               -GroupMembershipClaims "SecurityGroup" `
               -OrgRestrictions {orgrestrictions}
@@ -121,7 +121,7 @@ examples:
               ResourceSpecificApplicationPermissions:
               }
 
-              AppId                     : 4095dbc0-2095-42d3-b631-7a48eeede86c
+              AppId                     : 00001111-aaaa-2222-bbbb-3333cccc4444
               ApplicationTemplateId     :
               AppRoles                  : {class AppRole {
               AllowedMemberTypes: System.Collections.Generic.List`1[System.String]
@@ -152,7 +152,7 @@ examples:
               CustomKeyIdentifier: System.Byte[]
               DisplayName:
               EndDateTime:
-              KeyId: 11111111-1111-1111-1111-111111111111
+              KeyId: aaaaaaaa-0b0b-1c1c-2d2d-333333333333
               StartDateTime:
               Type: AsymmetricX509Cert
               Usage: Encrypt
@@ -185,7 +185,7 @@ examples:
               }
               SignInAudience            : AzureADandPersonalMicrosoftAccount
               Tags                      : {mytag}
-              TokenEncryptionKeyId      : 11111111-1111-1111-1111-111111111111
+              TokenEncryptionKeyId      : aaaaaaaa-0b0b-1c1c-2d2d-333333333333
               Web                       : class WebApplication {
               HomePageUrl:
               LogoutUrl: https://mynewapp.contoso.com/logout.html

--- a/azureadps-2.0-preview/AzureAD/New-AzureADMSApplicationExtensionProperty.md
+++ b/azureadps-2.0-preview/AzureAD/New-AzureADMSApplicationExtensionProperty.md
@@ -24,12 +24,12 @@ Creates an extension property on an application object.
 
 ### Example 1: Create an extension property
 ```
-PS C:\>New-AzureADMSApplicationExtensionProperty -ObjectId "3ddd22e7-a150-4bb3-b100-e410dea1cb84" -DataType "string" -Name "NewAttribute" -TargetObjects "Application"
+PS C:\>New-AzureADMSApplicationExtensionProperty -ObjectId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -DataType "string" -Name "NewAttribute" -TargetObjects "Application"
 
 
           ObjectId                             Name                                                    TargetObjects
           --------                             ----                                                    -------------
-          3ddd22e7-a150-4bb3-b100-e410dea1cb84 extension_36ee4c6c081240a2b820b22ebd02bce3_NewAttribute {}
+          aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb extension_36ee4c6c081240a2b820b22ebd02bce3_NewAttribute {}
 ```
 
 This command creates an application extension property of the string type for the specified object.
@@ -113,4 +113,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Get-AzureADMSApplicationExtensionProperty]()
 
 [Remove-AzureADMSApplicationExtensionProperty]()
-

--- a/azureadps-2.0-preview/AzureAD/New-AzureADMSApplicationExtensionProperty.yml
+++ b/azureadps-2.0-preview/AzureAD/New-AzureADMSApplicationExtensionProperty.yml
@@ -19,12 +19,12 @@ syntaxes:
 examples:
 - title: 'Example 1: Create an extension property'
   code: |-
-    PS C:\>New-AzureADMSApplicationExtensionProperty -ObjectId "3ddd22e7-a150-4bb3-b100-e410dea1cb84" -DataType "string" -Name "NewAttribute" -TargetObjects "Application"
+    PS C:\>New-AzureADMSApplicationExtensionProperty -ObjectId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -DataType "string" -Name "NewAttribute" -TargetObjects "Application"
 
 
               ObjectId                             Name                                                    TargetObjects
               --------                             ----                                                    -------------
-              3ddd22e7-a150-4bb3-b100-e410dea1cb84 extension_36ee4c6c081240a2b820b22ebd02bce3_NewAttribute {}
+              aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb extension_36ee4c6c081240a2b820b22ebd02bce3_NewAttribute {}
   description: |-
     This command creates an application extension property of the string type for the specified object.
   summary: ""

--- a/azureadps-2.0-preview/AzureAD/New-AzureADMSApplicationKey.md
+++ b/azureadps-2.0-preview/AzureAD/New-AzureADMSApplicationKey.md
@@ -24,7 +24,7 @@ Adds a new key to an application.
 
 ### Example 1: Add a key credential to an application
 ```
-PS C:\>New-AzureADMSApplicationKey -ObjectId 14a3f1ac-46a7-4d00-b1ca-0b2b84f033c2 -KeyCredential @{ key=[System.Convert]::FromBase64String("{base64cert}") } -PasswordCredential @{ displayname = "mypassword" } -Proof "{token}"
+PS C:\>New-AzureADMSApplicationKey -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb -KeyCredential @{ key=[System.Convert]::FromBase64String("{base64cert}") } -PasswordCredential @{ displayname = "mypassword" } -Proof "{token}"
 ```
 
 This command adds a key credential the specified application.
@@ -111,4 +111,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [Remove-AzureADMSApplicationKey]()
-


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/Azure/azure-docs-powershell-azuread/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
