### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs (part 7)

### DIFF
--- a/azureadps-2.0-preview/AzureAD/New-AzureADMSApplicationKey.yml
+++ b/azureadps-2.0-preview/AzureAD/New-AzureADMSApplicationKey.yml
@@ -21,7 +21,7 @@ syntaxes:
 examples:
 - title: 'Example 1: Add a key credential to an application'
   code: |-
-    PS C:\>New-AzureADMSApplicationKey -ObjectId 14a3f1ac-46a7-4d00-b1ca-0b2b84f033c2 -KeyCredential @{ key=[System.Convert]::FromBase64String("{base64cert}") } -PasswordCredential @{ displayname = "mypassword" } -Proof "{token}"
+    PS C:\>New-AzureADMSApplicationKey -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb -KeyCredential @{ key=[System.Convert]::FromBase64String("{base64cert}") } -PasswordCredential @{ displayname = "mypassword" } -Proof "{token}"
   description: |-
     This command adds a key credential the specified application.
   summary: ""

--- a/azureadps-2.0-preview/AzureAD/New-AzureADMSApplicationPassword.md
+++ b/azureadps-2.0-preview/AzureAD/New-AzureADMSApplicationPassword.md
@@ -24,12 +24,12 @@ Adds a strong password to an application.
 
 ### Example 1: Add a password to an application
 ```
-PS C:\>New-AzureADMSApplicationPassword -ObjectId 14a3f1ac-46a7-4d00-b1ca-0b2b84f033c2 -PasswordCredential @{ displayname = "mypassword" }
+PS C:\>New-AzureADMSApplicationPassword -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb -PasswordCredential @{ displayname = "mypassword" }
 
           CustomKeyIdentifier :
           EndDateTime         : 10/28/2021 3:57:37 PM
           DisplayName         :
-          KeyId               : 024c4c6e-87c3-4473-8e36-650f16bb730d
+          KeyId               : aaaaaaaa-0b0b-1c1c-2d2d-333333333333
           StartDateTime       : 10/28/2019 3:57:37 PM
           SecretText          : EQ:A-s45?Rt9/3Bp?7]-7__IO]3AG09E
           Hint                : EQ:
@@ -84,4 +84,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [Remove-AzureADMSApplicationPassword]()
-

--- a/azureadps-2.0-preview/AzureAD/New-AzureADMSApplicationPassword.yml
+++ b/azureadps-2.0-preview/AzureAD/New-AzureADMSApplicationPassword.yml
@@ -19,12 +19,12 @@ syntaxes:
 examples:
 - title: 'Example 1: Add a password to an application'
   code: |-
-    PS C:\>New-AzureADMSApplicationPassword -ObjectId 14a3f1ac-46a7-4d00-b1ca-0b2b84f033c2 -PasswordCredential @{ displayname = "mypassword" }
+    PS C:\>New-AzureADMSApplicationPassword -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb -PasswordCredential @{ displayname = "mypassword" }
 
               CustomKeyIdentifier :
               EndDateTime         : 10/28/2021 3:57:37 PM
               DisplayName         :
-              KeyId               : 024c4c6e-87c3-4473-8e36-650f16bb730d
+              KeyId               : aaaaaaaa-0b0b-1c1c-2d2d-333333333333
               StartDateTime       : 10/28/2019 3:57:37 PM
               SecretText          : EQ:A-s45?Rt9/3Bp?7]-7__IO]3AG09E
               Hint                : EQ:

--- a/azureadps-2.0-preview/AzureAD/New-AzureADMSPasswordSingleSignOnCredential.md
+++ b/azureadps-2.0-preview/AzureAD/New-AzureADMSPasswordSingleSignOnCredential.md
@@ -31,7 +31,7 @@ PS C:\> $creds1 = [Microsoft.Open.MSGraph.Model.PasswordSSOCredential]@{FieldId=
 PS C:\> $creds2 = [Microsoft.Open.MSGraph.Model.PasswordSSOCredential]@{FieldId="param_2"; Value="my-secret"; Type="password"}
 PS C:\> $credentials.Credentials = @($creds1, $creds2)
 
-PS C:\> $new_creds_output = New-AzureADMSPasswordSingleSignOnCredential -ObjectId 9ac9883e-0ac5-4c32-8737-4267f56a28cc -PasswordSSOCredential $credentials
+PS C:\> $new_creds_output = New-AzureADMSPasswordSingleSignOnCredential -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb -PasswordSSOCredential $credentials
 ```
 
 This command creates the password sso credentials for the given ObjectId and PasswordSSOObjectId.

--- a/azureadps-2.0-preview/AzureAD/New-AzureADMSPasswordSingleSignOnCredential.yml
+++ b/azureadps-2.0-preview/AzureAD/New-AzureADMSPasswordSingleSignOnCredential.yml
@@ -20,7 +20,7 @@ examples:
     PS C:\> $creds2 = [Microsoft.Open.MSGraph.Model.PasswordSSOCredential]@{FieldId="param_2"; Value="my-secret"; Type="password"}
     PS C:\> $credentials.Credentials = @($creds1, $creds2)
 
-    PS C:\> $new_creds_output = New-AzureADMSPasswordSingleSignOnCredential -ObjectId 9ac9883e-0ac5-4c32-8737-4267f56a28cc -PasswordSSOCredential $credentials
+    PS C:\> $new_creds_output = New-AzureADMSPasswordSingleSignOnCredential -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb -PasswordSSOCredential $credentials
   description: |-
     This command creates the password sso credentials for the given ObjectId and PasswordSSOObjectId.
   summary: ""

--- a/azureadps-2.0-preview/AzureAD/New-AzureADMSPermissionGrantConditionSet.md
+++ b/azureadps-2.0-preview/AzureAD/New-AzureADMSPermissionGrantConditionSet.md
@@ -44,14 +44,14 @@ New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "in
 
 ### Example 2: Create a permission grant condition set in an existing policy that includes specific permissions for a resource application
 ```
-New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "includes" -PermissionType "delegated" -Permissions @("8b590330-0eb2-45d0-baca-a00ecf7e7b87", "dac1c8fa-e6e4-47b8-a128-599660b8cd5c", "f6db0cc3-88cd-4c74-a374-3d8c7cc4c50b") -ResourceApplication "ec8d61c9-1cb2-4edb-afb0-bcda85645555"
+New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "includes" -PermissionType "delegated" -Permissions @("1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5", "2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6", "3cccccc3-4dd4-5ee5-6ff6-7aaaaaaaaaa7") -ResourceApplication "4dddddd4-5ee5-6ff6-7aa7-8bbbbbbbbbb8"
 
 				Id                                          : 64032dc4-8423-4fd7-930c-a9ed3bb1dbb4
 				PermissionType                              : delegated
 				PermissionClassification                    : all
-				ResourceApplication                         : ec8d61c9-1cb2-4edb-afb0-bcda85645555
-				Permissions                                 : {8b590330-0eb2-45d0-baca-a00ecf7e7b87, dac1c8fa-e6e4-47b8-a128-599660b8cd5c, 
-															  f6db0cc3-88cd-4c74-a374-3d8c7cc4c50b}
+				ResourceApplication                         : 4dddddd4-5ee5-6ff6-7aa7-8bbbbbbbbbb8
+				Permissions                                 : {1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5, 2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6, 
+															  3cccccc3-4dd4-5ee5-6ff6-7aaaaaaaaaa7}
 				ClientApplicationIds                        : {all}
 				ClientApplicationTenantIds                  : {all}
 				ClientApplicationPublisherIds               : {all}
@@ -60,16 +60,16 @@ New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "in
 
 ### Example 3: Create a permission grant condition set in an existing policy that is excluded
 ```
-New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "excludes" -PermissionType "delegated" -Permissions @("8b590330-0eb2-45d0-baca-a00ecf7e7b87", "dac1c8fa-e6e4-47b8-a128-599660b8cd5c", "f6db0cc3-88cd-4c74-a374-3d8c7cc4c50b") -ResourceApplication "ec8d61c9-1cb2-4edb-afb0-bcda85645555" -PermissionClassification "low" -ClientApplicationsFromVerifiedPublisherOnly $true -ClientApplicationIds @("4a6c40ea-edc1-4202-8620-dd4060ee6583", "17a961bd-e743-4e6f-8097-d7e6612999a7") -ClientApplicationTenantIds @("17a961bd-e743-4e6f-8097-d7e6612999a8", "17a961bd-e743-4e6f-8097-d7e6612999a9", "17a961bd-e743-4e6f-8097-d7e6612999a0") -ClientApplicationPublisherIds @("verifiedpublishermpnid")
+New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "excludes" -PermissionType "delegated" -Permissions @("1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5", "2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6", "3cccccc3-4dd4-5ee5-6ff6-7aaaaaaaaaa7") -ResourceApplication "4dddddd4-5ee5-6ff6-7aa7-8bbbbbbbbbb8" -PermissionClassification "low" -ClientApplicationsFromVerifiedPublisherOnly $true -ClientApplicationIds @("5eeeeee5-6ff6-7aa7-8bb8-9cccccccccc9", "6ffffff6-7aa7-8bb8-9cc9-0dddddddddd0") -ClientApplicationTenantIds @("7aaaaaa7-8bb8-9cc9-0dd0-1eeeeeeeeee1", "1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5", "2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6") -ClientApplicationPublisherIds @("verifiedpublishermpnid")
 
 			Id                                          : 0f81cce0-a766-4db6-a7e2-4e5f10f6abf8
 			PermissionType                              : delegated
 			PermissionClassification                    : low
-			ResourceApplication                         : ec8d61c9-1cb2-4edb-afb0-bcda85645555
-			Permissions                                 : {8b590330-0eb2-45d0-baca-a00ecf7e7b87, dac1c8fa-e6e4-47b8-a128-599660b8cd5c, 
-														  f6db0cc3-88cd-4c74-a374-3d8c7cc4c50b}
-			ClientApplicationIds                        : {4a6c40ea-edc1-4202-8620-dd4060ee6583, 17a961bd-e743-4e6f-8097-d7e6612999a7}
-			ClientApplicationTenantIds                  : {17a961bd-e743-4e6f-8097-d7e6612999a8, 17a961bd-e743-4e6f-8097-d7e6612999a9, 17a961bd-e743-4e6f-8097-d7e6612999a0}
+			ResourceApplication                         : 4dddddd4-5ee5-6ff6-7aa7-8bbbbbbbbbb8
+			Permissions                                 : {1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5, 2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6, 
+														  3cccccc3-4dd4-5ee5-6ff6-7aaaaaaaaaa7}
+			ClientApplicationIds                        : {5eeeeee5-6ff6-7aa7-8bb8-9cccccccccc9, 6ffffff6-7aa7-8bb8-9cc9-0dddddddddd0}
+			ClientApplicationTenantIds                  : {7aaaaaa7-8bb8-9cc9-0dd0-1eeeeeeeeee1, 1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5, 2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6}
 			ClientApplicationPublisherIds               : {verifiedpublishermpnid}
 			ClientApplicationsFromVerifiedPublisherOnly : True
 ```
@@ -253,4 +253,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Get-AzureADMSPermissionGrantConditionSet]()
 
 [Remove-AzureADMSPermissionGrantConditionSet]()
-

--- a/azureadps-2.0-preview/AzureAD/New-AzureADMSPermissionGrantConditionSet.md
+++ b/azureadps-2.0-preview/AzureAD/New-AzureADMSPermissionGrantConditionSet.md
@@ -44,14 +44,14 @@ New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "in
 
 ### Example 2: Create a permission grant condition set in an existing policy that includes specific permissions for a resource application
 ```
-New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "includes" -PermissionType "delegated" -Permissions @("1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5", "2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6", "3cccccc3-4dd4-5ee5-6ff6-7aaaaaaaaaa7") -ResourceApplication "4dddddd4-5ee5-6ff6-7aa7-8bbbbbbbbbb8"
+New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "includes" -PermissionType "delegated" -Permissions @("8b590330-0eb2-45d0-baca-a00ecf7e7b87", "dac1c8fa-e6e4-47b8-a128-599660b8cd5c", "f6db0cc3-88cd-4c74-a374-3d8c7cc4c50b") -ResourceApplication "ec8d61c9-1cb2-4edb-afb0-bcda85645555"
 
 				Id                                          : 64032dc4-8423-4fd7-930c-a9ed3bb1dbb4
 				PermissionType                              : delegated
 				PermissionClassification                    : all
-				ResourceApplication                         : 4dddddd4-5ee5-6ff6-7aa7-8bbbbbbbbbb8
-				Permissions                                 : {1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5, 2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6, 
-															  3cccccc3-4dd4-5ee5-6ff6-7aaaaaaaaaa7}
+				ResourceApplication                         : ec8d61c9-1cb2-4edb-afb0-bcda85645555
+				Permissions                                 : {8b590330-0eb2-45d0-baca-a00ecf7e7b87, dac1c8fa-e6e4-47b8-a128-599660b8cd5c, 
+															  f6db0cc3-88cd-4c74-a374-3d8c7cc4c50b}
 				ClientApplicationIds                        : {all}
 				ClientApplicationTenantIds                  : {all}
 				ClientApplicationPublisherIds               : {all}
@@ -60,16 +60,16 @@ New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "in
 
 ### Example 3: Create a permission grant condition set in an existing policy that is excluded
 ```
-New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "excludes" -PermissionType "delegated" -Permissions @("1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5", "2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6", "3cccccc3-4dd4-5ee5-6ff6-7aaaaaaaaaa7") -ResourceApplication "4dddddd4-5ee5-6ff6-7aa7-8bbbbbbbbbb8" -PermissionClassification "low" -ClientApplicationsFromVerifiedPublisherOnly $true -ClientApplicationIds @("5eeeeee5-6ff6-7aa7-8bb8-9cccccccccc9", "6ffffff6-7aa7-8bb8-9cc9-0dddddddddd0") -ClientApplicationTenantIds @("7aaaaaa7-8bb8-9cc9-0dd0-1eeeeeeeeee1", "1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5", "2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6") -ClientApplicationPublisherIds @("verifiedpublishermpnid")
+New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "excludes" -PermissionType "delegated" -Permissions @("8b590330-0eb2-45d0-baca-a00ecf7e7b87", "dac1c8fa-e6e4-47b8-a128-599660b8cd5c", "f6db0cc3-88cd-4c74-a374-3d8c7cc4c50b") -ResourceApplication "ec8d61c9-1cb2-4edb-afb0-bcda85645555" -PermissionClassification "low" -ClientApplicationsFromVerifiedPublisherOnly $true -ClientApplicationIds @("00001111-aaaa-2222-bbbb-3333cccc4444", "11112222-bbbb-3333-cccc-4444dddd5555") -ClientApplicationTenantIds @("aaaabbbb-0000-cccc-1111-dddd2222eeee", "bbbbcccc-1111-dddd-2222-eeee3333ffff", "ccccdddd-2222-eeee-3333-ffff4444aaaa") -ClientApplicationPublisherIds @("verifiedpublishermpnid")
 
 			Id                                          : 0f81cce0-a766-4db6-a7e2-4e5f10f6abf8
 			PermissionType                              : delegated
 			PermissionClassification                    : low
-			ResourceApplication                         : 4dddddd4-5ee5-6ff6-7aa7-8bbbbbbbbbb8
-			Permissions                                 : {1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5, 2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6, 
-														  3cccccc3-4dd4-5ee5-6ff6-7aaaaaaaaaa7}
-			ClientApplicationIds                        : {5eeeeee5-6ff6-7aa7-8bb8-9cccccccccc9, 6ffffff6-7aa7-8bb8-9cc9-0dddddddddd0}
-			ClientApplicationTenantIds                  : {7aaaaaa7-8bb8-9cc9-0dd0-1eeeeeeeeee1, 1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5, 2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6}
+			ResourceApplication                         : ec8d61c9-1cb2-4edb-afb0-bcda85645555
+			Permissions                                 : {8b590330-0eb2-45d0-baca-a00ecf7e7b87, dac1c8fa-e6e4-47b8-a128-599660b8cd5c, 
+														  f6db0cc3-88cd-4c74-a374-3d8c7cc4c50b}
+			ClientApplicationIds                        : {00001111-aaaa-2222-bbbb-3333cccc4444, 11112222-bbbb-3333-cccc-4444dddd5555}
+			ClientApplicationTenantIds                  : {aaaabbbb-0000-cccc-1111-dddd2222eeee, bbbbcccc-1111-dddd-2222-eeee3333ffff, ccccdddd-2222-eeee-3333-ffff4444aaaa}
 			ClientApplicationPublisherIds               : {verifiedpublishermpnid}
 			ClientApplicationsFromVerifiedPublisherOnly : True
 ```

--- a/azureadps-2.0-preview/AzureAD/New-AzureADMSPermissionGrantConditionSet.yml
+++ b/azureadps-2.0-preview/AzureAD/New-AzureADMSPermissionGrantConditionSet.yml
@@ -44,14 +44,14 @@ examples:
   summary: ""
 - title: 'Example 2: Create a permission grant condition set in an existing policy that includes specific permissions for a resource application'
   code: |-
-    New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "includes" -PermissionType "delegated" -Permissions @("8b590330-0eb2-45d0-baca-a00ecf7e7b87", "dac1c8fa-e6e4-47b8-a128-599660b8cd5c", "f6db0cc3-88cd-4c74-a374-3d8c7cc4c50b") -ResourceApplication "ec8d61c9-1cb2-4edb-afb0-bcda85645555"
+    New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "includes" -PermissionType "delegated" -Permissions @("1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5", "2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6", "3cccccc3-4dd4-5ee5-6ff6-7aaaaaaaaaa7") -ResourceApplication "4dddddd4-5ee5-6ff6-7aa7-8bbbbbbbbbb8"
 
     				Id                                          : 64032dc4-8423-4fd7-930c-a9ed3bb1dbb4
     				PermissionType                              : delegated
     				PermissionClassification                    : all
-    				ResourceApplication                         : ec8d61c9-1cb2-4edb-afb0-bcda85645555
-    				Permissions                                 : {8b590330-0eb2-45d0-baca-a00ecf7e7b87, dac1c8fa-e6e4-47b8-a128-599660b8cd5c, 
-    															  f6db0cc3-88cd-4c74-a374-3d8c7cc4c50b}
+    				ResourceApplication                         : 4dddddd4-5ee5-6ff6-7aa7-8bbbbbbbbbb8
+    				Permissions                                 : {1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5, 2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6, 
+    															  3cccccc3-4dd4-5ee5-6ff6-7aaaaaaaaaa7}
     				ClientApplicationIds                        : {all}
     				ClientApplicationTenantIds                  : {all}
     				ClientApplicationPublisherIds               : {all}
@@ -60,16 +60,16 @@ examples:
   summary: ""
 - title: 'Example 3: Create a permission grant condition set in an existing policy that is excluded'
   code: |-
-    New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "excludes" -PermissionType "delegated" -Permissions @("8b590330-0eb2-45d0-baca-a00ecf7e7b87", "dac1c8fa-e6e4-47b8-a128-599660b8cd5c", "f6db0cc3-88cd-4c74-a374-3d8c7cc4c50b") -ResourceApplication "ec8d61c9-1cb2-4edb-afb0-bcda85645555" -PermissionClassification "low" -ClientApplicationsFromVerifiedPublisherOnly $true -ClientApplicationIds @("4a6c40ea-edc1-4202-8620-dd4060ee6583", "17a961bd-e743-4e6f-8097-d7e6612999a7") -ClientApplicationTenantIds @("17a961bd-e743-4e6f-8097-d7e6612999a8", "17a961bd-e743-4e6f-8097-d7e6612999a9", "17a961bd-e743-4e6f-8097-d7e6612999a0") -ClientApplicationPublisherIds @("verifiedpublishermpnid")
+    New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "excludes" -PermissionType "delegated" -Permissions @("1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5", "2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6", "3cccccc3-4dd4-5ee5-6ff6-7aaaaaaaaaa7") -ResourceApplication "4dddddd4-5ee5-6ff6-7aa7-8bbbbbbbbbb8" -PermissionClassification "low" -ClientApplicationsFromVerifiedPublisherOnly $true -ClientApplicationIds @("5eeeeee5-6ff6-7aa7-8bb8-9cccccccccc9", "6ffffff6-7aa7-8bb8-9cc9-0dddddddddd0") -ClientApplicationTenantIds @("7aaaaaa7-8bb8-9cc9-0dd0-1eeeeeeeeee1", "1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5", "2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6") -ClientApplicationPublisherIds @("verifiedpublishermpnid")
 
     			Id                                          : 0f81cce0-a766-4db6-a7e2-4e5f10f6abf8
     			PermissionType                              : delegated
     			PermissionClassification                    : low
-    			ResourceApplication                         : ec8d61c9-1cb2-4edb-afb0-bcda85645555
-    			Permissions                                 : {8b590330-0eb2-45d0-baca-a00ecf7e7b87, dac1c8fa-e6e4-47b8-a128-599660b8cd5c, 
-    														  f6db0cc3-88cd-4c74-a374-3d8c7cc4c50b}
-    			ClientApplicationIds                        : {4a6c40ea-edc1-4202-8620-dd4060ee6583, 17a961bd-e743-4e6f-8097-d7e6612999a7}
-    			ClientApplicationTenantIds                  : {17a961bd-e743-4e6f-8097-d7e6612999a8, 17a961bd-e743-4e6f-8097-d7e6612999a9, 17a961bd-e743-4e6f-8097-d7e6612999a0}
+    			ResourceApplication                         : 4dddddd4-5ee5-6ff6-7aa7-8bbbbbbbbbb8
+    			Permissions                                 : {1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5, 2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6, 
+    														  3cccccc3-4dd4-5ee5-6ff6-7aaaaaaaaaa7}
+    			ClientApplicationIds                        : {5eeeeee5-6ff6-7aa7-8bb8-9cccccccccc9, 6ffffff6-7aa7-8bb8-9cc9-0dddddddddd0}
+    			ClientApplicationTenantIds                  : {7aaaaaa7-8bb8-9cc9-0dd0-1eeeeeeeeee1, 1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5, 2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6}
     			ClientApplicationPublisherIds               : {verifiedpublishermpnid}
     			ClientApplicationsFromVerifiedPublisherOnly : True
   description: ""

--- a/azureadps-2.0-preview/AzureAD/New-AzureADMSPermissionGrantConditionSet.yml
+++ b/azureadps-2.0-preview/AzureAD/New-AzureADMSPermissionGrantConditionSet.yml
@@ -44,14 +44,14 @@ examples:
   summary: ""
 - title: 'Example 2: Create a permission grant condition set in an existing policy that includes specific permissions for a resource application'
   code: |-
-    New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "includes" -PermissionType "delegated" -Permissions @("1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5", "2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6", "3cccccc3-4dd4-5ee5-6ff6-7aaaaaaaaaa7") -ResourceApplication "4dddddd4-5ee5-6ff6-7aa7-8bbbbbbbbbb8"
+    New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "includes" -PermissionType "delegated" -Permissions @("8b590330-0eb2-45d0-baca-a00ecf7e7b87", "dac1c8fa-e6e4-47b8-a128-599660b8cd5c", "f6db0cc3-88cd-4c74-a374-3d8c7cc4c50b") -ResourceApplication "ec8d61c9-1cb2-4edb-afb0-bcda85645555"
 
     				Id                                          : 64032dc4-8423-4fd7-930c-a9ed3bb1dbb4
     				PermissionType                              : delegated
     				PermissionClassification                    : all
-    				ResourceApplication                         : 4dddddd4-5ee5-6ff6-7aa7-8bbbbbbbbbb8
-    				Permissions                                 : {1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5, 2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6, 
-    															  3cccccc3-4dd4-5ee5-6ff6-7aaaaaaaaaa7}
+				ResourceApplication                         : ec8d61c9-1cb2-4edb-afb0-bcda85645555
+				Permissions                                 : {8b590330-0eb2-45d0-baca-a00ecf7e7b87, dac1c8fa-e6e4-47b8-a128-599660b8cd5c, 
+															  f6db0cc3-88cd-4c74-a374-3d8c7cc4c50b}
     				ClientApplicationIds                        : {all}
     				ClientApplicationTenantIds                  : {all}
     				ClientApplicationPublisherIds               : {all}
@@ -60,16 +60,16 @@ examples:
   summary: ""
 - title: 'Example 3: Create a permission grant condition set in an existing policy that is excluded'
   code: |-
-    New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "excludes" -PermissionType "delegated" -Permissions @("1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5", "2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6", "3cccccc3-4dd4-5ee5-6ff6-7aaaaaaaaaa7") -ResourceApplication "4dddddd4-5ee5-6ff6-7aa7-8bbbbbbbbbb8" -PermissionClassification "low" -ClientApplicationsFromVerifiedPublisherOnly $true -ClientApplicationIds @("5eeeeee5-6ff6-7aa7-8bb8-9cccccccccc9", "6ffffff6-7aa7-8bb8-9cc9-0dddddddddd0") -ClientApplicationTenantIds @("7aaaaaa7-8bb8-9cc9-0dd0-1eeeeeeeeee1", "1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5", "2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6") -ClientApplicationPublisherIds @("verifiedpublishermpnid")
+    New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "excludes" -PermissionType "delegated" -Permissions @("8b590330-0eb2-45d0-baca-a00ecf7e7b87", "dac1c8fa-e6e4-47b8-a128-599660b8cd5c", "f6db0cc3-88cd-4c74-a374-3d8c7cc4c50b") -ResourceApplication "ec8d61c9-1cb2-4edb-afb0-bcda85645555" -PermissionClassification "low" -ClientApplicationsFromVerifiedPublisherOnly $true -ClientApplicationIds @("00001111-aaaa-2222-bbbb-3333cccc4444", "11112222-bbbb-3333-cccc-4444dddd5555") -ClientApplicationTenantIds @("aaaabbbb-0000-cccc-1111-dddd2222eeee", "bbbbcccc-1111-dddd-2222-eeee3333ffff", "ccccdddd-2222-eeee-3333-ffff4444aaaa") -ClientApplicationPublisherIds @("verifiedpublishermpnid")
 
     			Id                                          : 0f81cce0-a766-4db6-a7e2-4e5f10f6abf8
     			PermissionType                              : delegated
     			PermissionClassification                    : low
-    			ResourceApplication                         : 4dddddd4-5ee5-6ff6-7aa7-8bbbbbbbbbb8
-    			Permissions                                 : {1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5, 2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6, 
-    														  3cccccc3-4dd4-5ee5-6ff6-7aaaaaaaaaa7}
-    			ClientApplicationIds                        : {5eeeeee5-6ff6-7aa7-8bb8-9cccccccccc9, 6ffffff6-7aa7-8bb8-9cc9-0dddddddddd0}
-    			ClientApplicationTenantIds                  : {7aaaaaa7-8bb8-9cc9-0dd0-1eeeeeeeeee1, 1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5, 2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6}
+			ResourceApplication                         : ec8d61c9-1cb2-4edb-afb0-bcda85645555
+			Permissions                                 : {8b590330-0eb2-45d0-baca-a00ecf7e7b87, dac1c8fa-e6e4-47b8-a128-599660b8cd5c, 
+														  f6db0cc3-88cd-4c74-a374-3d8c7cc4c50b}
+			ClientApplicationIds                        : {00001111-aaaa-2222-bbbb-3333cccc4444, 11112222-bbbb-3333-cccc-4444dddd5555}
+			ClientApplicationTenantIds                  : {aaaabbbb-0000-cccc-1111-dddd2222eeee, bbbbcccc-1111-dddd-2222-eeee3333ffff, ccccdddd-2222-eeee-3333-ffff4444aaaa}
     			ClientApplicationPublisherIds               : {verifiedpublishermpnid}
     			ClientApplicationsFromVerifiedPublisherOnly : True
   description: ""

--- a/azureadps-2.0-preview/AzureAD/New-AzureADMSRoleAssignment.md
+++ b/azureadps-2.0-preview/AzureAD/New-AzureADMSRoleAssignment.md
@@ -24,7 +24,7 @@ The New-AzureADMSRoleAssignment cmdlet creates an Azure Active Directory (Azure 
 
 ### Example 1
 ```powershell
-PS C:\> New-AzureADMSRoleAssignment -RoleDefinitionId 62e90356-69f5-4237-9190-012177145e10 -PrincipalId 69584089-b4d1-4055-9c94-320412efd653 -ResourceScope '/'
+PS C:\> New-AzureADMSRoleAssignment -RoleDefinitionId 62e90356-69f5-4237-9190-012177145e10 -PrincipalId aaaaaaaa-bbbb-cccc-1111-222222222222 -ResourceScope '/'
 ```
 
 This command creates a new role assignment.

--- a/azureadps-2.0-preview/AzureAD/New-AzureADMSRoleAssignment.yml
+++ b/azureadps-2.0-preview/AzureAD/New-AzureADMSRoleAssignment.yml
@@ -17,7 +17,7 @@ syntaxes:
 examples:
 - title: Example 1
   code: |-
-    PS C:\> New-AzureADMSRoleAssignment -RoleDefinitionId 62e90356-69f5-4237-9190-012177145e10 -PrincipalId 69584089-b4d1-4055-9c94-320412efd653 -ResourceScope '/'
+    PS C:\> New-AzureADMSRoleAssignment -RoleDefinitionId 62e90356-69f5-4237-9190-012177145e10 -PrincipalId aaaaaaaa-bbbb-cccc-1111-222222222222 -ResourceScope '/'
   description: |-
     This command creates a new role assignment.
   summary: ""

--- a/azureadps-2.0-preview/AzureAD/Open-AzureADMSPrivilegedRoleAssignmentRequest.md
+++ b/azureadps-2.0-preview/AzureAD/Open-AzureADMSPrivilegedRoleAssignmentRequest.md
@@ -30,7 +30,7 @@ $schedule = New-Object Microsoft.Open.MSGraph.Model.AzureADMSPrivilegedSchedule
 $schedule.Type = "Once"
 $schedule.StartDateTime = "2019-04-26T20:49:11.770Z"
 $schedule.endDateTime = "2019-07-25T20:49:11.770Z"
-Open-AzureADMSPrivilegedRoleAssignmentRequest -ProviderId AzureResources -Schedule $schedule -ResourceId "e5e7d29d-5465-45ac-885f-4716a5ee74b5" -RoleDefinitionId "9f8c1837-f885-4dfd-9a75-990f9222b21d" -SubjectId "a25004a3-eceb-4ad4-b4aa-9485356bc55b" -AssignmentState "Eligible" -Type "AdminAdd"
+Open-AzureADMSPrivilegedRoleAssignmentRequest -ProviderId AzureResources -Schedule $schedule -ResourceId "a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1" -RoleDefinitionId "b1b1b1b1-cccc-dddd-eeee-f2f2f2f2f2f2" -SubjectId "c2c2c2c2-dddd-eeee-ffff-a3a3a3a3a3a3" -AssignmentState "Eligible" -Type "AdminAdd"
 ```
 
 This example creates a role assignment request.
@@ -48,7 +48,7 @@ $schedule.Type = 'Once'
 $schedule.StartDateTime = $start.ToString('yyyy-MM-ddTHH:mm:ss.fffZ')
 $schedule.endDateTime = $end.ToString('yyyy-MM-ddTHH:mm:ss.fffZ')
 
-Open-AzureADMSPrivilegedRoleAssignmentRequest -ProviderId AzureResources -Schedule $schedule -ResourceId "e5e7d29d-5465-45ac-885f-4716a5ee74b5" -RoleDefinitionId "9f8c1837-f885-4dfd-9a75-990f9222b21d" -SubjectId "a25004a3-eceb-4ad4-b4aa-9485356bc55b" -AssignmentState "Active" -Type "UserAdd"
+Open-AzureADMSPrivilegedRoleAssignmentRequest -ProviderId AzureResources -Schedule $schedule -ResourceId "a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1" -RoleDefinitionId "b1b1b1b1-cccc-dddd-eeee-f2f2f2f2f2f2" -SubjectId "c2c2c2c2-dddd-eeee-ffff-a3a3a3a3a3a3" -AssignmentState "Active" -Type "UserAdd"
 ```
 
 This example creates a role assignment request activating the Admin Role.
@@ -66,7 +66,7 @@ $schedule.Type = 'Once'
 $schedule.StartDateTime = $start.ToString('yyyy-MM-ddTHH:mm:ss.fffZ')
 $schedule.endDateTime = $end.ToString('yyyy-MM-ddTHH:mm:ss.fffZ')
 
-Open-AzureADMSPrivilegedRoleAssignmentRequest -ProviderId AzureResources -Schedule $schedule -ResourceId "e5e7d29d-5465-45ac-885f-4716a5ee74b5" -RoleDefinitionId "9f8c1837-f885-4dfd-9a75-990f9222b21d" -SubjectId "a25004a3-eceb-4ad4-b4aa-9485356bc55b" -AssignmentState "Active" -Type "UserRemove"
+Open-AzureADMSPrivilegedRoleAssignmentRequest -ProviderId AzureResources -Schedule $schedule -ResourceId "a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1" -RoleDefinitionId "b1b1b1b1-cccc-dddd-eeee-f2f2f2f2f2f2" -SubjectId "c2c2c2c2-dddd-eeee-ffff-a3a3a3a3a3a3" -AssignmentState "Active" -Type "UserRemove"
 ```
 
 This example creates a role assignment request disabling the Admin Role.

--- a/azureadps-2.0-preview/AzureAD/Open-AzureADMSPrivilegedRoleAssignmentRequest.yml
+++ b/azureadps-2.0-preview/AzureAD/Open-AzureADMSPrivilegedRoleAssignmentRequest.yml
@@ -26,7 +26,7 @@ examples:
     $schedule.Type = "Once"
     $schedule.StartDateTime = "2019-04-26T20:49:11.770Z"
     $schedule.endDateTime = "2019-07-25T20:49:11.770Z"
-    Open-AzureADMSPrivilegedRoleAssignmentRequest -ProviderId AzureResources -Schedule $schedule -ResourceId "e5e7d29d-5465-45ac-885f-4716a5ee74b5" -RoleDefinitionId "9f8c1837-f885-4dfd-9a75-990f9222b21d" -SubjectId "a25004a3-eceb-4ad4-b4aa-9485356bc55b" -AssignmentState "Eligible" -Type "AdminAdd"
+    Open-AzureADMSPrivilegedRoleAssignmentRequest -ProviderId AzureResources -Schedule $schedule -ResourceId "a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1" -RoleDefinitionId "b1b1b1b1-cccc-dddd-eeee-f2f2f2f2f2f2" -SubjectId "c2c2c2c2-dddd-eeee-ffff-a3a3a3a3a3a3" -AssignmentState "Eligible" -Type "AdminAdd"
   description: |-
     This example creates a role assignment request.
   summary: ""
@@ -42,7 +42,7 @@ examples:
     $schedule.StartDateTime = $start.ToString('yyyy-MM-ddTHH:mm:ss.fffZ')
     $schedule.endDateTime = $end.ToString('yyyy-MM-ddTHH:mm:ss.fffZ')
 
-    Open-AzureADMSPrivilegedRoleAssignmentRequest -ProviderId AzureResources -Schedule $schedule -ResourceId "e5e7d29d-5465-45ac-885f-4716a5ee74b5" -RoleDefinitionId "9f8c1837-f885-4dfd-9a75-990f9222b21d" -SubjectId "a25004a3-eceb-4ad4-b4aa-9485356bc55b" -AssignmentState "Active" -Type "UserAdd"
+    Open-AzureADMSPrivilegedRoleAssignmentRequest -ProviderId AzureResources -Schedule $schedule -ResourceId "a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1" -RoleDefinitionId "b1b1b1b1-cccc-dddd-eeee-f2f2f2f2f2f2" -SubjectId "c2c2c2c2-dddd-eeee-ffff-a3a3a3a3a3a3" -AssignmentState "Active" -Type "UserAdd"
   description: |-
     This example creates a role assignment request activating the Admin Role.
   summary: ""
@@ -58,7 +58,7 @@ examples:
     $schedule.StartDateTime = $start.ToString('yyyy-MM-ddTHH:mm:ss.fffZ')
     $schedule.endDateTime = $end.ToString('yyyy-MM-ddTHH:mm:ss.fffZ')
 
-    Open-AzureADMSPrivilegedRoleAssignmentRequest -ProviderId AzureResources -Schedule $schedule -ResourceId "e5e7d29d-5465-45ac-885f-4716a5ee74b5" -RoleDefinitionId "9f8c1837-f885-4dfd-9a75-990f9222b21d" -SubjectId "a25004a3-eceb-4ad4-b4aa-9485356bc55b" -AssignmentState "Active" -Type "UserRemove"
+    Open-AzureADMSPrivilegedRoleAssignmentRequest -ProviderId AzureResources -Schedule $schedule -ResourceId "a0a0a0a0-bbbb-cccc-dddd-e1e1e1e1e1e1" -RoleDefinitionId "b1b1b1b1-cccc-dddd-eeee-f2f2f2f2f2f2" -SubjectId "c2c2c2c2-dddd-eeee-ffff-a3a3a3a3a3a3" -AssignmentState "Active" -Type "UserRemove"
   description: |-
     This example creates a role assignment request disabling the Admin Role.
   summary: ""

--- a/azureadps-2.0-preview/AzureAD/Remove-AzureADApplication.md
+++ b/azureadps-2.0-preview/AzureAD/Remove-AzureADApplication.md
@@ -27,7 +27,7 @@ The **Remove-AzureADApplication** cmdlet removes the specified application from 
 
 ### Example 1: Remove an application
 ```
-PS C:\>Remove-AzureADApplication -ObjectId "acd10942-5747-4385-8824-4c5d5fa904f9"
+PS C:\>Remove-AzureADApplication -ObjectId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
 ```
 
 This command removes the specified application.

--- a/azureadps-2.0-preview/AzureAD/Remove-AzureADApplication.yml
+++ b/azureadps-2.0-preview/AzureAD/Remove-AzureADApplication.yml
@@ -18,7 +18,7 @@ syntaxes:
 examples:
 - title: 'Example 1: Remove an application'
   code: |-
-    PS C:\>Remove-AzureADApplication -ObjectId "acd10942-5747-4385-8824-4c5d5fa904f9"
+    PS C:\>Remove-AzureADApplication -ObjectId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
   description: |-
     This command removes the specified application.
   summary: ""

--- a/azureadps-2.0-preview/AzureAD/Remove-AzureADApplicationExtensionProperty.md
+++ b/azureadps-2.0-preview/AzureAD/Remove-AzureADApplicationExtensionProperty.md
@@ -27,7 +27,7 @@ The **Remove-AzureADApplicationExtensionProperty** cmdlet removes an application
 
 ### Example 1: Remove an extension property
 ```
-PS C:\> Remove-AzureADApplicationExtensionProperty -ObjectId "3ddd22e7-a150-4bb3-b100-e410dea1cb84" -ExtensionPropertyId "344ed560-f8e7-410e-ab9f-c79df5c36"
+PS C:\> Remove-AzureADApplicationExtensionProperty -ObjectId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -ExtensionPropertyId "344ed560-f8e7-410e-ab9f-c79df5c36"
 ```
 
 This command removes the extension property that has the specified ID from an application in Azure Active Directory.

--- a/azureadps-2.0-preview/AzureAD/Remove-AzureADApplicationExtensionProperty.yml
+++ b/azureadps-2.0-preview/AzureAD/Remove-AzureADApplicationExtensionProperty.yml
@@ -16,7 +16,7 @@ syntaxes:
 examples:
 - title: 'Example 1: Remove an extension property'
   code: |-
-    PS C:\> Remove-AzureADApplicationExtensionProperty -ObjectId "3ddd22e7-a150-4bb3-b100-e410dea1cb84" -ExtensionPropertyId "344ed560-f8e7-410e-ab9f-c79df5c36"
+    PS C:\> Remove-AzureADApplicationExtensionProperty -ObjectId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -ExtensionPropertyId "344ed560-f8e7-410e-ab9f-c79df5c36"
   description: |-
     This command removes the extension property that has the specified ID from an application in Azure Active Directory.
   summary: ""

--- a/azureadps-2.0-preview/AzureAD/Remove-AzureADApplicationKeyCredential.md
+++ b/azureadps-2.0-preview/AzureAD/Remove-AzureADApplicationKeyCredential.md
@@ -27,7 +27,7 @@ The **Remove-AzureADApplicationKeyCredential** cmdlet removes a key credential f
 
 ### Example 1: Remove a key credential
 ```
-PS C:\> Remove-AzureADApplicationKeyCredential -ObjectId "3ddd22e7-a150-4bb3-b100-e410dea1cb84" -KeyId "6aa971c6-3040-45df-87ed-581c8c09ff2b"
+PS C:\> Remove-AzureADApplicationKeyCredential -ObjectId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -KeyId "aaaaaaaa-0b0b-1c1c-2d2d-333333333333"
 ```
 
 This command removes the specified key credential from the specified application.

--- a/azureadps-2.0-preview/AzureAD/Remove-AzureADApplicationKeyCredential.yml
+++ b/azureadps-2.0-preview/AzureAD/Remove-AzureADApplicationKeyCredential.yml
@@ -16,7 +16,7 @@ syntaxes:
 examples:
 - title: 'Example 1: Remove a key credential'
   code: |-
-    PS C:\> Remove-AzureADApplicationKeyCredential -ObjectId "3ddd22e7-a150-4bb3-b100-e410dea1cb84" -KeyId "6aa971c6-3040-45df-87ed-581c8c09ff2b"
+    PS C:\> Remove-AzureADApplicationKeyCredential -ObjectId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -KeyId "aaaaaaaa-0b0b-1c1c-2d2d-333333333333"
   description: |-
     This command removes the specified key credential from the specified application.
   summary: ""

--- a/azureadps-2.0-preview/AzureAD/Remove-AzureADApplicationOwner.md
+++ b/azureadps-2.0-preview/AzureAD/Remove-AzureADApplicationOwner.md
@@ -27,7 +27,7 @@ The **Remove-AzureADApplicationOwner** cmdlet removes an owner from an applicati
 
 ### Example 1: Remove an owner from an application
 ```
-PS C:\>Remove-AzureADApplicationOwner -ObjectId "3ddd22e7-a150-4bb3-b100-e410dea1cb84" -OwnerId "c13dd34a-492b-4561-b171-40fcce2916c5"
+PS C:\>Remove-AzureADApplicationOwner -ObjectId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -OwnerId "bbbbbbbb-1111-2222-3333-cccccccccccc"
 ```
 
 This command removes the owner from the specified application.

--- a/azureadps-2.0-preview/AzureAD/Remove-AzureADApplicationOwner.yml
+++ b/azureadps-2.0-preview/AzureAD/Remove-AzureADApplicationOwner.yml
@@ -16,7 +16,7 @@ syntaxes:
 examples:
 - title: 'Example 1: Remove an owner from an application'
   code: |-
-    PS C:\>Remove-AzureADApplicationOwner -ObjectId "3ddd22e7-a150-4bb3-b100-e410dea1cb84" -OwnerId "c13dd34a-492b-4561-b171-40fcce2916c5"
+    PS C:\>Remove-AzureADApplicationOwner -ObjectId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -OwnerId "bbbbbbbb-1111-2222-3333-cccccccccccc"
   description: |-
     This command removes the owner from the specified application.
   summary: ""

--- a/azureadps-2.0-preview/AzureAD/Remove-AzureADApplicationProxyApplication.md
+++ b/azureadps-2.0-preview/AzureAD/Remove-AzureADApplicationProxyApplication.md
@@ -24,14 +24,14 @@ The Remove-AzureADApplicationProxyApplication cmdlet removes Application Proxy c
 
 ### Example 1
 ```
-PS C:\> Remove-AzureADApplicationProxyApplication -ObjectId 257098d1-f8dd-4efb-88a2-1c92d3654f10
+PS C:\> Remove-AzureADApplicationProxyApplication -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
 ```
 
 Example 1: Remove a Proxy Application
 
 ### Example 2
 ```
-PS C:\> Remove-AzureADApplicationProxyApplication -ObjectId 0d7b0f02-3f63-414d-8d20-4b8bd0291e42 -RemoveADApplication $true
+PS C:\> Remove-AzureADApplicationProxyApplication -ObjectId bbbbbbbb-1111-2222-3333-cccccccccccc -RemoveADApplication $true
 ```
 
 Example 2: Remove a Proxy Application, and remove it from Azure AD completely


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/Azure/azure-docs-powershell-azuread/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
