### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs (part 16)

### DIFF
--- a/azureadps-2.0/AzureAD/New-AzureADApplicationKeyCredential.yml
+++ b/azureadps-2.0/AzureAD/New-AzureADApplicationKeyCredential.yml
@@ -21,7 +21,7 @@ examples:
 
     CustomKeyIdentifier : {84, 101, 115, 116}
     EndDate             : 11/7/2017 12:00:00 AM
-    KeyId               : a5845538-3f67-402d-a03e-36d768f1441e
+    KeyId               : aaaaaaaa-0b0b-1c1c-2d2d-333333333333
     StartDate           : 11/7/2016 12:00:00 AM
     Type                : Symmetric
     Usage               : Sign

--- a/azureadps-2.0/AzureAD/New-AzureADApplicationPasswordCredential.md
+++ b/azureadps-2.0/AzureAD/New-AzureADApplicationPasswordCredential.md
@@ -25,7 +25,7 @@ The New-AzureADApplicationPasswordCredential cmdlet creates a password credentia
 
 ### Example 1: Create a password credential
 ```
-PS C:\>New-AzureADApplicationPasswordCredential -ObjectId "3ddd22e7-a150-4bb3-b100-e410dea1cb84"
+PS C:\>New-AzureADApplicationPasswordCredential -ObjectId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
 
 CustomKeyIdentifier :
 EndDate             : 9/28/2017 3:57:10 PM
@@ -35,7 +35,7 @@ Value               : ZJ0V1Yg4cp4eWIey9DrYspqVdX1pdvY437P/ueGxVLU=
 ```
 ### Example 2: Create a custom password credential 
 ```
-PS C:\>New-AzureADApplicationPasswordCredential -ObjectId '6e6a6561-e96d-453b-9641-743b499736cc' -Value 'Zihjfg-dsgs_d34_54"73fE"d!f~dg'
+PS C:\>New-AzureADApplicationPasswordCredential -ObjectId 'bbbbbbbb-1111-2222-3333-cccccccccccc' -Value 'Zihjfg-dsgs_d34_54"73fE"d!f~dg'
  
 CustomKeyIdentifier :
 EndDate             : 16-12-2023 06:00:44
@@ -173,4 +173,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Get-AzureADApplicationPasswordCredential]()
 
 [Remove-AzureADApplicationPasswordCredential]()
-

--- a/azureadps-2.0/AzureAD/New-AzureADApplicationPasswordCredential.yml
+++ b/azureadps-2.0/AzureAD/New-AzureADApplicationPasswordCredential.yml
@@ -13,7 +13,7 @@ syntaxes:
 examples:
 - title: 'Example 1: Create a password credential'
   code: |-
-    PS C:\>New-AzureADApplicationPasswordCredential -ObjectId "3ddd22e7-a150-4bb3-b100-e410dea1cb84"
+    PS C:\>New-AzureADApplicationPasswordCredential -ObjectId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
 
     CustomKeyIdentifier :
     EndDate             : 9/28/2017 3:57:10 PM

--- a/azureadps-2.0/AzureAD/New-AzureADMSApplication.md
+++ b/azureadps-2.0/AzureAD/New-AzureADMSApplication.md
@@ -53,14 +53,14 @@ PS C:\>New-AzureADMSApplication `
           -InformationalUrl @{ SupportUrl = "https://mynewapp.contoso.com/support.html" } `
           -IsDeviceOnlyAuthSupported $false `
           -IsFallbackPublicClient $false `
-          -KeyCredentials @{ KeyId = "11111111-1111-1111-1111-111111111111"; Usage = "Encrypt"; Key = {cert}; Type = "AsymmetricX509Cert" } `
+          -KeyCredentials @{ KeyId = "aaaaaaaa-0b0b-1c1c-2d2d-333333333333"; Usage = "Encrypt"; Key = {cert}; Type = "AsymmetricX509Cert" } `
           -OptionalClaims @{ IdToken = [PSCustomObject]@{ Name = "claimName"; Source = "claimSource" } } `
           -ParentalControlSettings @{ LegalAgeGroupRule = "Block" } `
           -PublicClient @{ RedirectUris = "https://mynewapp.contoso.com/" } `
           -RequiredResourceAccess @{ ResourceAppId = "31111111-1111-1111-1111-111111111111"; ResourceAccess = [PSCustomObject]@{ Type = "Scope" } } `
           -SignInAudience AzureADandPersonalMicrosoftAccount `
           -Tags "mytag" `
-          -TokenEncryptionKeyId "11111111-1111-1111-1111-111111111111" `
+          -TokenEncryptionKeyId "aaaaaaaa-0b0b-1c1c-2d2d-333333333333" `
           -Web @{ LogoutUrl = "https://mynewapp.contoso.com/logout.html" } `
           -GroupMembershipClaims "SecurityGroup" `
           -PasswordCredentials {passwordcredentials}
@@ -81,7 +81,7 @@ PS C:\>New-AzureADMSApplication `
           Oauth2PermissionScopes:
           System.Collections.Generic.List`1[Microsoft.Open.MSGraph.Model.PermissionScope]
 
-          AppId                     : 4095dbc0-2095-42d3-b631-7a48eeede86c
+          AppId                     : 00001111-aaaa-2222-bbbb-3333cccc4444
           ApplicationTemplateId     :
           AppRoles                  : {class AppRole {
           AllowedMemberTypes: System.Collections.Generic.List`1[System.String]
@@ -112,7 +112,7 @@ PS C:\>New-AzureADMSApplication `
           CustomKeyIdentifier: System.Byte[]
           DisplayName:
           EndDateTime:
-          KeyId: 11111111-1111-1111-1111-111111111111
+          KeyId: aaaaaaaa-0b0b-1c1c-2d2d-333333333333
           StartDateTime:
           Type: AsymmetricX509Cert
           Usage: Encrypt
@@ -145,7 +145,7 @@ PS C:\>New-AzureADMSApplication `
           }
           SignInAudience            : AzureADandPersonalMicrosoftAccount
           Tags                      : {mytag}
-          TokenEncryptionKeyId      : 11111111-1111-1111-1111-111111111111
+          TokenEncryptionKeyId      : aaaaaaaa-0b0b-1c1c-2d2d-333333333333
           Web                       : class WebApplication {
           HomePageUrl:
           LogoutUrl: https://mynewapp.contoso.com/logout.html

--- a/azureadps-2.0/AzureAD/New-AzureADMSApplication.yml
+++ b/azureadps-2.0/AzureAD/New-AzureADMSApplication.yml
@@ -83,14 +83,14 @@ examples:
               -InformationalUrl @{ SupportUrl = "https://mynewapp.contoso.com/support.html" } `
               -IsDeviceOnlyAuthSupported $false `
               -IsFallbackPublicClient $false `
-              -KeyCredentials @{ KeyId = "11111111-1111-1111-1111-111111111111"; Usage = "Encrypt"; Key = {cert}; Type = "AsymmetricX509Cert" } `
+              -KeyCredentials @{ KeyId = "aaaaaaaa-0b0b-1c1c-2d2d-333333333333"; Usage = "Encrypt"; Key = {cert}; Type = "AsymmetricX509Cert" } `
               -OptionalClaims @{ IdToken = [PSCustomObject]@{ Name = "claimName"; Source = "claimSource" } } `
               -ParentalControlSettings @{ LegalAgeGroupRule = "Block" } `
               -PublicClient @{ RedirectUris = "https://mynewapp.contoso.com/" } `
               -RequiredResourceAccess @{ ResourceAppId = "31111111-1111-1111-1111-111111111111"; ResourceAccess = [PSCustomObject]@{ Type = "Scope" } } `
               -SignInAudience AzureADandPersonalMicrosoftAccount `
               -Tags "mytag" `
-              -TokenEncryptionKeyId "11111111-1111-1111-1111-111111111111" `
+              -TokenEncryptionKeyId "aaaaaaaa-0b0b-1c1c-2d2d-333333333333" `
               -Web @{ LogoutUrl = "https://mynewapp.contoso.com/logout.html" } `
               -GroupMembershipClaims "SecurityGroup" `
               -PasswordCredentials {passwordcredentials}
@@ -111,7 +111,7 @@ examples:
               Oauth2PermissionScopes:
               System.Collections.Generic.List`1[Microsoft.Open.MSGraph.Model.PermissionScope]
 
-              AppId                     : 4095dbc0-2095-42d3-b631-7a48eeede86c
+              AppId                     : 00001111-aaaa-2222-bbbb-3333cccc4444
               ApplicationTemplateId     :
               AppRoles                  : {class AppRole {
               AllowedMemberTypes: System.Collections.Generic.List`1[System.String]
@@ -142,7 +142,7 @@ examples:
               CustomKeyIdentifier: System.Byte[]
               DisplayName:
               EndDateTime:
-              KeyId: 11111111-1111-1111-1111-111111111111
+              KeyId: aaaaaaaa-0b0b-1c1c-2d2d-333333333333
               StartDateTime:
               Type: AsymmetricX509Cert
               Usage: Encrypt
@@ -175,7 +175,7 @@ examples:
               }
               SignInAudience            : AzureADandPersonalMicrosoftAccount
               Tags                      : {mytag}
-              TokenEncryptionKeyId      : 11111111-1111-1111-1111-111111111111
+              TokenEncryptionKeyId      : aaaaaaaa-0b0b-1c1c-2d2d-333333333333
               Web                       : class WebApplication {
               HomePageUrl:
               LogoutUrl: https://mynewapp.contoso.com/logout.html

--- a/azureadps-2.0/AzureAD/New-AzureADMSApplicationExtensionProperty.md
+++ b/azureadps-2.0/AzureAD/New-AzureADMSApplicationExtensionProperty.md
@@ -24,12 +24,12 @@ Creates an extension property on an application object.
 
 ### Example 1: Create an extension property
 ```
-PS C:\>New-AzureADMSApplicationExtensionProperty -ObjectId "3ddd22e7-a150-4bb3-b100-e410dea1cb84" -DataType "string" -Name "NewAttribute" -TargetObjects "Application"
+PS C:\>New-AzureADMSApplicationExtensionProperty -ObjectId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -DataType "string" -Name "NewAttribute" -TargetObjects "Application"
 
 
           ObjectId                             Name                                                    TargetObjects
           --------                             ----                                                    -------------
-          3ddd22e7-a150-4bb3-b100-e410dea1cb84 extension_36ee4c6c081240a2b820b22ebd02bce3_NewAttribute {}
+          aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb extension_36ee4c6c081240a2b820b22ebd02bce3_NewAttribute {}
 ```
 
 This command creates an application extension property of the string type for the specified object.
@@ -113,4 +113,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Get-AzureADMSApplicationExtensionProperty]()
 
 [Remove-AzureADMSApplicationExtensionProperty]()
-

--- a/azureadps-2.0/AzureAD/New-AzureADMSApplicationExtensionProperty.yml
+++ b/azureadps-2.0/AzureAD/New-AzureADMSApplicationExtensionProperty.yml
@@ -19,12 +19,12 @@ syntaxes:
 examples:
 - title: 'Example 1: Create an extension property'
   code: |-
-    PS C:\>New-AzureADMSApplicationExtensionProperty -ObjectId "3ddd22e7-a150-4bb3-b100-e410dea1cb84" -DataType "string" -Name "NewAttribute" -TargetObjects "Application"
+    PS C:\>New-AzureADMSApplicationExtensionProperty -ObjectId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -DataType "string" -Name "NewAttribute" -TargetObjects "Application"
 
 
               ObjectId                             Name                                                    TargetObjects
               --------                             ----                                                    -------------
-              3ddd22e7-a150-4bb3-b100-e410dea1cb84 extension_36ee4c6c081240a2b820b22ebd02bce3_NewAttribute {}
+              aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb extension_36ee4c6c081240a2b820b22ebd02bce3_NewAttribute {}
   description: |-
     This command creates an application extension property of the string type for the specified object.
   summary: ""

--- a/azureadps-2.0/AzureAD/New-AzureADMSApplicationKey.md
+++ b/azureadps-2.0/AzureAD/New-AzureADMSApplicationKey.md
@@ -24,7 +24,7 @@ Adds a new key to an application.
 
 ### Example 1: Add a key credential to an application
 ```
-PS C:\>New-AzureADMSApplicationKey -ObjectId 14a3f1ac-46a7-4d00-b1ca-0b2b84f033c2 -KeyCredential @{ key=[System.Convert]::FromBase64String("{base64cert}") } -PasswordCredential @{ displayname = "mypassword" } -Proof "{token}"
+PS C:\>New-AzureADMSApplicationKey -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb -KeyCredential @{ key=[System.Convert]::FromBase64String("{base64cert}") } -PasswordCredential @{ displayname = "mypassword" } -Proof "{token}"
 ```
 
 This command adds a key credential the specified application.
@@ -111,4 +111,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [Remove-AzureADMSApplicationKey]()
-

--- a/azureadps-2.0/AzureAD/New-AzureADMSApplicationKey.yml
+++ b/azureadps-2.0/AzureAD/New-AzureADMSApplicationKey.yml
@@ -21,7 +21,7 @@ syntaxes:
 examples:
 - title: 'Example 1: Add a key credential to an application'
   code: |-
-    PS C:\>New-AzureADMSApplicationKey -ObjectId 14a3f1ac-46a7-4d00-b1ca-0b2b84f033c2 -KeyCredential @{ key=[System.Convert]::FromBase64String("{base64cert}") } -PasswordCredential @{ displayname = "mypassword" } -Proof "{token}"
+    PS C:\>New-AzureADMSApplicationKey -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb -KeyCredential @{ key=[System.Convert]::FromBase64String("{base64cert}") } -PasswordCredential @{ displayname = "mypassword" } -Proof "{token}"
   description: |-
     This command adds a key credential the specified application.
   summary: ""

--- a/azureadps-2.0/AzureAD/New-AzureADMSApplicationPassword.md
+++ b/azureadps-2.0/AzureAD/New-AzureADMSApplicationPassword.md
@@ -24,12 +24,12 @@ Adds a strong password to an application.
 
 ### Example 1: Add a password to an application
 ```
-PS C:\>New-AzureADMSApplicationPassword -ObjectId 14a3f1ac-46a7-4d00-b1ca-0b2b84f033c2 -PasswordCredential @{ displayname = "mypassword" }
+PS C:\>New-AzureADMSApplicationPassword -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb -PasswordCredential @{ displayname = "mypassword" }
 
           CustomKeyIdentifier :
           EndDateTime         : 10/28/2021 3:57:37 PM
           DisplayName         :
-          KeyId               : 024c4c6e-87c3-4473-8e36-650f16bb730d
+          KeyId               : aaaaaaaa-0b0b-1c1c-2d2d-333333333333
           StartDateTime       : 10/28/2019 3:57:37 PM
           SecretText          : EQ:A-s45?Rt9/3Bp?7]-7__IO]3AG09E
           Hint                : EQ:
@@ -84,4 +84,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [Remove-AzureADMSApplicationPassword]()
-

--- a/azureadps-2.0/AzureAD/New-AzureADMSApplicationPassword.yml
+++ b/azureadps-2.0/AzureAD/New-AzureADMSApplicationPassword.yml
@@ -19,12 +19,12 @@ syntaxes:
 examples:
 - title: 'Example 1: Add a password to an application'
   code: |-
-    PS C:\>New-AzureADMSApplicationPassword -ObjectId 14a3f1ac-46a7-4d00-b1ca-0b2b84f033c2 -PasswordCredential @{ displayname = "mypassword" }
+    PS C:\>New-AzureADMSApplicationPassword -ObjectId aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb -PasswordCredential @{ displayname = "mypassword" }
 
               CustomKeyIdentifier :
               EndDateTime         : 10/28/2021 3:57:37 PM
               DisplayName         :
-              KeyId               : 024c4c6e-87c3-4473-8e36-650f16bb730d
+              KeyId               : aaaaaaaa-0b0b-1c1c-2d2d-333333333333
               StartDateTime       : 10/28/2019 3:57:37 PM
               SecretText          : EQ:A-s45?Rt9/3Bp?7]-7__IO]3AG09E
               Hint                : EQ:

--- a/azureadps-2.0/AzureAD/New-AzureADMSPermissionGrantConditionSet.md
+++ b/azureadps-2.0/AzureAD/New-AzureADMSPermissionGrantConditionSet.md
@@ -44,14 +44,14 @@ New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "in
 
 ### Example 2: Create a permission grant condition set in an existing policy that includes specific permissions for a resource application
 ```
-New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "includes" -PermissionType "delegated" -Permissions @("8b590330-0eb2-45d0-baca-a00ecf7e7b87", "dac1c8fa-e6e4-47b8-a128-599660b8cd5c", "f6db0cc3-88cd-4c74-a374-3d8c7cc4c50b") -ResourceApplication "ec8d61c9-1cb2-4edb-afb0-bcda85645555"
+New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "includes" -PermissionType "delegated" -Permissions @("1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5", "2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6", "3cccccc3-4dd4-5ee5-6ff6-7aaaaaaaaaa7") -ResourceApplication "4dddddd4-5ee5-6ff6-7aa7-8bbbbbbbbbb8"
 
 				Id                                          : 64032dc4-8423-4fd7-930c-a9ed3bb1dbb4
 				PermissionType                              : delegated
 				PermissionClassification                    : all
-				ResourceApplication                         : ec8d61c9-1cb2-4edb-afb0-bcda85645555
-				Permissions                                 : {8b590330-0eb2-45d0-baca-a00ecf7e7b87, dac1c8fa-e6e4-47b8-a128-599660b8cd5c, 
-															  f6db0cc3-88cd-4c74-a374-3d8c7cc4c50b}
+				ResourceApplication                         : 4dddddd4-5ee5-6ff6-7aa7-8bbbbbbbbbb8
+				Permissions                                 : {1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5, 2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6, 
+															  3cccccc3-4dd4-5ee5-6ff6-7aaaaaaaaaa7}
 				ClientApplicationIds                        : {all}
 				ClientApplicationTenantIds                  : {all}
 				ClientApplicationPublisherIds               : {all}
@@ -60,16 +60,16 @@ New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "in
 
 ### Example 3: Create a permission grant condition set in an existing policy that is excluded
 ```
-New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "excludes" -PermissionType "delegated" -Permissions @("8b590330-0eb2-45d0-baca-a00ecf7e7b87", "dac1c8fa-e6e4-47b8-a128-599660b8cd5c", "f6db0cc3-88cd-4c74-a374-3d8c7cc4c50b") -ResourceApplication "ec8d61c9-1cb2-4edb-afb0-bcda85645555" -PermissionClassification "low" -ClientApplicationsFromVerifiedPublisherOnly $true -ClientApplicationIds @("4a6c40ea-edc1-4202-8620-dd4060ee6583", "17a961bd-e743-4e6f-8097-d7e6612999a7") -ClientApplicationTenantIds @("17a961bd-e743-4e6f-8097-d7e6612999a8", "17a961bd-e743-4e6f-8097-d7e6612999a9", "17a961bd-e743-4e6f-8097-d7e6612999a0") -ClientApplicationPublisherIds @("verifiedpublishermpnid")
+New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "excludes" -PermissionType "delegated" -Permissions @("1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5", "2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6", "3cccccc3-4dd4-5ee5-6ff6-7aaaaaaaaaa7") -ResourceApplication "4dddddd4-5ee5-6ff6-7aa7-8bbbbbbbbbb8" -PermissionClassification "low" -ClientApplicationsFromVerifiedPublisherOnly $true -ClientApplicationIds @("5eeeeee5-6ff6-7aa7-8bb8-9cccccccccc9", "6ffffff6-7aa7-8bb8-9cc9-0dddddddddd0") -ClientApplicationTenantIds @("7aaaaaa7-8bb8-9cc9-0dd0-1eeeeeeeeee1", "1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5", "2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6") -ClientApplicationPublisherIds @("verifiedpublishermpnid")
 
 			Id                                          : 0f81cce0-a766-4db6-a7e2-4e5f10f6abf8
 			PermissionType                              : delegated
 			PermissionClassification                    : low
-			ResourceApplication                         : ec8d61c9-1cb2-4edb-afb0-bcda85645555
-			Permissions                                 : {8b590330-0eb2-45d0-baca-a00ecf7e7b87, dac1c8fa-e6e4-47b8-a128-599660b8cd5c, 
-														  f6db0cc3-88cd-4c74-a374-3d8c7cc4c50b}
-			ClientApplicationIds                        : {4a6c40ea-edc1-4202-8620-dd4060ee6583, 17a961bd-e743-4e6f-8097-d7e6612999a7}
-			ClientApplicationTenantIds                  : {17a961bd-e743-4e6f-8097-d7e6612999a8, 17a961bd-e743-4e6f-8097-d7e6612999a9, 17a961bd-e743-4e6f-8097-d7e6612999a0}
+			ResourceApplication                         : 4dddddd4-5ee5-6ff6-7aa7-8bbbbbbbbbb8
+			Permissions                                 : {1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5, 2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6, 
+														  3cccccc3-4dd4-5ee5-6ff6-7aaaaaaaaaa7}
+			ClientApplicationIds                        : {5eeeeee5-6ff6-7aa7-8bb8-9cccccccccc9, 6ffffff6-7aa7-8bb8-9cc9-0dddddddddd0}
+			ClientApplicationTenantIds                  : {7aaaaaa7-8bb8-9cc9-0dd0-1eeeeeeeeee1, 1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5, 2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6}
 			ClientApplicationPublisherIds               : {verifiedpublishermpnid}
 			ClientApplicationsFromVerifiedPublisherOnly : True
 ```
@@ -257,4 +257,3 @@ See the [migration guide for New-AzureADMSPermissionGrantConditionSet](./migrate
 [Get-AzureADMSPermissionGrantConditionSet](Get-AzureADMSPermissionGrantConditionSet.md)
 
 [Remove-AzureADMSPermissionGrantConditionSet](Remove-AzureADMSPermissionGrantConditionSet.md)
-

--- a/azureadps-2.0/AzureAD/New-AzureADMSPermissionGrantConditionSet.md
+++ b/azureadps-2.0/AzureAD/New-AzureADMSPermissionGrantConditionSet.md
@@ -44,14 +44,14 @@ New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "in
 
 ### Example 2: Create a permission grant condition set in an existing policy that includes specific permissions for a resource application
 ```
-New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "includes" -PermissionType "delegated" -Permissions @("1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5", "2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6", "3cccccc3-4dd4-5ee5-6ff6-7aaaaaaaaaa7") -ResourceApplication "4dddddd4-5ee5-6ff6-7aa7-8bbbbbbbbbb8"
+New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "includes" -PermissionType "delegated" -Permissions @("8b590330-0eb2-45d0-baca-a00ecf7e7b87", "dac1c8fa-e6e4-47b8-a128-599660b8cd5c", "f6db0cc3-88cd-4c74-a374-3d8c7cc4c50b") -ResourceApplication "ec8d61c9-1cb2-4edb-afb0-bcda85645555"
 
 				Id                                          : 64032dc4-8423-4fd7-930c-a9ed3bb1dbb4
 				PermissionType                              : delegated
 				PermissionClassification                    : all
-				ResourceApplication                         : 4dddddd4-5ee5-6ff6-7aa7-8bbbbbbbbbb8
-				Permissions                                 : {1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5, 2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6, 
-															  3cccccc3-4dd4-5ee5-6ff6-7aaaaaaaaaa7}
+				ResourceApplication                         : ec8d61c9-1cb2-4edb-afb0-bcda85645555
+				Permissions                                 : {8b590330-0eb2-45d0-baca-a00ecf7e7b87, dac1c8fa-e6e4-47b8-a128-599660b8cd5c 
+															  f6db0cc3-88cd-4c74-a374-3d8c7cc4c50b}
 				ClientApplicationIds                        : {all}
 				ClientApplicationTenantIds                  : {all}
 				ClientApplicationPublisherIds               : {all}
@@ -60,16 +60,16 @@ New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "in
 
 ### Example 3: Create a permission grant condition set in an existing policy that is excluded
 ```
-New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "excludes" -PermissionType "delegated" -Permissions @("1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5", "2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6", "3cccccc3-4dd4-5ee5-6ff6-7aaaaaaaaaa7") -ResourceApplication "4dddddd4-5ee5-6ff6-7aa7-8bbbbbbbbbb8" -PermissionClassification "low" -ClientApplicationsFromVerifiedPublisherOnly $true -ClientApplicationIds @("5eeeeee5-6ff6-7aa7-8bb8-9cccccccccc9", "6ffffff6-7aa7-8bb8-9cc9-0dddddddddd0") -ClientApplicationTenantIds @("7aaaaaa7-8bb8-9cc9-0dd0-1eeeeeeeeee1", "1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5", "2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6") -ClientApplicationPublisherIds @("verifiedpublishermpnid")
+New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "excludes" -PermissionType "delegated" -Permissions @("8b590330-0eb2-45d0-baca-a00ecf7e7b87", "dac1c8fa-e6e4-47b8-a128-599660b8cd5c", "f6db0cc3-88cd-4c74-a374-3d8c7cc4c50b") -ResourceApplication "ec8d61c9-1cb2-4edb-afb0-bcda85645555" -PermissionClassification "low" -ClientApplicationsFromVerifiedPublisherOnly $true -ClientApplicationIds @("00001111-aaaa-2222-bbbb-3333cccc4444", "11112222-bbbb-3333-cccc-4444dddd5555") -ClientApplicationTenantIds @("aaaabbbb-0000-cccc-1111-dddd2222eeee", "bbbbcccc-1111-dddd-2222-eeee3333ffff", "ccccdddd-2222-eeee-3333-ffff4444aaaa") -ClientApplicationPublisherIds @("verifiedpublishermpnid")
 
 			Id                                          : 0f81cce0-a766-4db6-a7e2-4e5f10f6abf8
 			PermissionType                              : delegated
 			PermissionClassification                    : low
-			ResourceApplication                         : 4dddddd4-5ee5-6ff6-7aa7-8bbbbbbbbbb8
-			Permissions                                 : {1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5, 2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6, 
-														  3cccccc3-4dd4-5ee5-6ff6-7aaaaaaaaaa7}
-			ClientApplicationIds                        : {5eeeeee5-6ff6-7aa7-8bb8-9cccccccccc9, 6ffffff6-7aa7-8bb8-9cc9-0dddddddddd0}
-			ClientApplicationTenantIds                  : {7aaaaaa7-8bb8-9cc9-0dd0-1eeeeeeeeee1, 1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5, 2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6}
+			ResourceApplication                         : ec8d61c9-1cb2-4edb-afb0-bcda85645555
+			Permissions                                 : {8b590330-0eb2-45d0-baca-a00ecf7e7b87, dac1c8fa-e6e4-47b8-a128-599660b8cd5c, 
+														  f6db0cc3-88cd-4c74-a374-3d8c7cc4c50b}
+			ClientApplicationIds                        : {00001111-aaaa-2222-bbbb-3333cccc4444, 11112222-bbbb-3333-cccc-4444dddd5555}
+			ClientApplicationTenantIds                  : {aaaabbbb-0000-cccc-1111-dddd2222eeee, bbbbcccc-1111-dddd-2222-eeee3333ffff, ccccdddd-2222-eeee-3333-ffff4444aaaa}
 			ClientApplicationPublisherIds               : {verifiedpublishermpnid}
 			ClientApplicationsFromVerifiedPublisherOnly : True
 ```

--- a/azureadps-2.0/AzureAD/New-AzureADMSPermissionGrantConditionSet.yml
+++ b/azureadps-2.0/AzureAD/New-AzureADMSPermissionGrantConditionSet.yml
@@ -44,14 +44,14 @@ examples:
   summary: ""
 - title: 'Example 2: Create a permission grant condition set in an existing policy that includes specific permissions for a resource application'
   code: |-
-    New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "includes" -PermissionType "delegated" -Permissions @("1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5", "2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6", "3cccccc3-4dd4-5ee5-6ff6-7aaaaaaaaaa7") -ResourceApplication "4dddddd4-5ee5-6ff6-7aa7-8bbbbbbbbbb8"
+    New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "includes" -PermissionType "delegated" -Permissions @("8b590330-0eb2-45d0-baca-a00ecf7e7b87", "dac1c8fa-e6e4-47b8-a128-599660b8cd5c", "f6db0cc3-88cd-4c74-a374-3d8c7cc4c50b") -ResourceApplication "ec8d61c9-1cb2-4edb-afb0-bcda85645555"
 
     				Id                                          : 64032dc4-8423-4fd7-930c-a9ed3bb1dbb4
     				PermissionType                              : delegated
     				PermissionClassification                    : all
-    				ResourceApplication                         : 4dddddd4-5ee5-6ff6-7aa7-8bbbbbbbbbb8
-    				Permissions                                 : {1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5, 2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6, 
-    															  3cccccc3-4dd4-5ee5-6ff6-7aaaaaaaaaa7}
+    				ResourceApplication                         : ec8d61c9-1cb2-4edb-afb0-bcda85645555
+    				Permissions                                 : {8b590330-0eb2-45d0-baca-a00ecf7e7b87, dac1c8fa-e6e4-47b8-a128-599660b8cd5c,
+    															  f6db0cc3-88cd-4c74-a374-3d8c7cc4c50b}
     				ClientApplicationIds                        : {all}
     				ClientApplicationTenantIds                  : {all}
     				ClientApplicationPublisherIds               : {all}
@@ -60,16 +60,16 @@ examples:
   summary: ""
 - title: 'Example 3: Create a permission grant condition set in an existing policy that is excluded'
   code: |-
-    New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "excludes" -PermissionType "delegated" -Permissions @("1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5", "2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6", "3cccccc3-4dd4-5ee5-6ff6-7aaaaaaaaaa7") -ResourceApplication "4dddddd4-5ee5-6ff6-7aa7-8bbbbbbbbbb8" -PermissionClassification "low" -ClientApplicationsFromVerifiedPublisherOnly $true -ClientApplicationIds @("5eeeeee5-6ff6-7aa7-8bb8-9cccccccccc9", "6ffffff6-7aa7-8bb8-9cc9-0dddddddddd0") -ClientApplicationTenantIds @("7aaaaaa7-8bb8-9cc9-0dd0-1eeeeeeeeee1", "1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5", "2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6") -ClientApplicationPublisherIds @("verifiedpublishermpnid")
+    New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "excludes" -PermissionType "delegated" -Permissions @("8b590330-0eb2-45d0-baca-a00ecf7e7b87", "dac1c8fa-e6e4-47b8-a128-599660b8cd5c", "f6db0cc3-88cd-4c74-a374-3d8c7cc4c50b") -ResourceApplication "ec8d61c9-1cb2-4edb-afb0-bcda85645555" -PermissionClassification "low" -ClientApplicationsFromVerifiedPublisherOnly $true -ClientApplicationIds @("00001111-aaaa-2222-bbbb-3333cccc4444", "11112222-bbbb-3333-cccc-4444dddd5555") -ClientApplicationTenantIds @("aaaabbbb-0000-cccc-1111-dddd2222eeee", "bbbbcccc-1111-dddd-2222-eeee3333ffff", "ccccdddd-2222-eeee-3333-ffff4444aaaa") -ClientApplicationPublisherIds @("verifiedpublishermpnid")
 
     			Id                                          : 0f81cce0-a766-4db6-a7e2-4e5f10f6abf8
     			PermissionType                              : delegated
     			PermissionClassification                    : low
     			ResourceApplication                         : 4dddddd4-5ee5-6ff6-7aa7-8bbbbbbbbbb8
-    			Permissions                                 : {1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5, 2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6, 
-    														  3cccccc3-4dd4-5ee5-6ff6-7aaaaaaaaaa7}
-    			ClientApplicationIds                        : {5eeeeee5-6ff6-7aa7-8bb8-9cccccccccc9, 6ffffff6-7aa7-8bb8-9cc9-0dddddddddd0}
-    			ClientApplicationTenantIds                  : {7aaaaaa7-8bb8-9cc9-0dd0-1eeeeeeeeee1, 1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5, 2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6}
+    			Permissions                                 : {8b590330-0eb2-45d0-baca-a00ecf7e7b87, dac1c8fa-e6e4-47b8-a128-599660b8cd5c, 
+    														  f6db0cc3-88cd-4c74-a374-3d8c7cc4c50b}
+    			ClientApplicationIds                        : {00001111-aaaa-2222-bbbb-3333cccc4444, 11112222-bbbb-3333-cccc-4444dddd5555}
+    			ClientApplicationTenantIds                  : {aaaabbbb-0000-cccc-1111-dddd2222eeee, bbbbcccc-1111-dddd-2222-eeee3333ffff, ccccdddd-2222-eeee-3333-ffff4444aaaa}
     			ClientApplicationPublisherIds               : {verifiedpublishermpnid}
     			ClientApplicationsFromVerifiedPublisherOnly : True
   description: ""

--- a/azureadps-2.0/AzureAD/New-AzureADMSPermissionGrantConditionSet.yml
+++ b/azureadps-2.0/AzureAD/New-AzureADMSPermissionGrantConditionSet.yml
@@ -44,14 +44,14 @@ examples:
   summary: ""
 - title: 'Example 2: Create a permission grant condition set in an existing policy that includes specific permissions for a resource application'
   code: |-
-    New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "includes" -PermissionType "delegated" -Permissions @("8b590330-0eb2-45d0-baca-a00ecf7e7b87", "dac1c8fa-e6e4-47b8-a128-599660b8cd5c", "f6db0cc3-88cd-4c74-a374-3d8c7cc4c50b") -ResourceApplication "ec8d61c9-1cb2-4edb-afb0-bcda85645555"
+    New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "includes" -PermissionType "delegated" -Permissions @("1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5", "2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6", "3cccccc3-4dd4-5ee5-6ff6-7aaaaaaaaaa7") -ResourceApplication "4dddddd4-5ee5-6ff6-7aa7-8bbbbbbbbbb8"
 
     				Id                                          : 64032dc4-8423-4fd7-930c-a9ed3bb1dbb4
     				PermissionType                              : delegated
     				PermissionClassification                    : all
-    				ResourceApplication                         : ec8d61c9-1cb2-4edb-afb0-bcda85645555
-    				Permissions                                 : {8b590330-0eb2-45d0-baca-a00ecf7e7b87, dac1c8fa-e6e4-47b8-a128-599660b8cd5c, 
-    															  f6db0cc3-88cd-4c74-a374-3d8c7cc4c50b}
+    				ResourceApplication                         : 4dddddd4-5ee5-6ff6-7aa7-8bbbbbbbbbb8
+    				Permissions                                 : {1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5, 2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6, 
+    															  3cccccc3-4dd4-5ee5-6ff6-7aaaaaaaaaa7}
     				ClientApplicationIds                        : {all}
     				ClientApplicationTenantIds                  : {all}
     				ClientApplicationPublisherIds               : {all}
@@ -60,16 +60,16 @@ examples:
   summary: ""
 - title: 'Example 3: Create a permission grant condition set in an existing policy that is excluded'
   code: |-
-    New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "excludes" -PermissionType "delegated" -Permissions @("8b590330-0eb2-45d0-baca-a00ecf7e7b87", "dac1c8fa-e6e4-47b8-a128-599660b8cd5c", "f6db0cc3-88cd-4c74-a374-3d8c7cc4c50b") -ResourceApplication "ec8d61c9-1cb2-4edb-afb0-bcda85645555" -PermissionClassification "low" -ClientApplicationsFromVerifiedPublisherOnly $true -ClientApplicationIds @("4a6c40ea-edc1-4202-8620-dd4060ee6583", "17a961bd-e743-4e6f-8097-d7e6612999a7") -ClientApplicationTenantIds @("17a961bd-e743-4e6f-8097-d7e6612999a8", "17a961bd-e743-4e6f-8097-d7e6612999a9", "17a961bd-e743-4e6f-8097-d7e6612999a0") -ClientApplicationPublisherIds @("verifiedpublishermpnid")
+    New-AzureADMSPermissionGrantConditionSet -PolicyId "test1" -ConditionSetType "excludes" -PermissionType "delegated" -Permissions @("1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5", "2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6", "3cccccc3-4dd4-5ee5-6ff6-7aaaaaaaaaa7") -ResourceApplication "4dddddd4-5ee5-6ff6-7aa7-8bbbbbbbbbb8" -PermissionClassification "low" -ClientApplicationsFromVerifiedPublisherOnly $true -ClientApplicationIds @("5eeeeee5-6ff6-7aa7-8bb8-9cccccccccc9", "6ffffff6-7aa7-8bb8-9cc9-0dddddddddd0") -ClientApplicationTenantIds @("7aaaaaa7-8bb8-9cc9-0dd0-1eeeeeeeeee1", "1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5", "2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6") -ClientApplicationPublisherIds @("verifiedpublishermpnid")
 
     			Id                                          : 0f81cce0-a766-4db6-a7e2-4e5f10f6abf8
     			PermissionType                              : delegated
     			PermissionClassification                    : low
-    			ResourceApplication                         : ec8d61c9-1cb2-4edb-afb0-bcda85645555
-    			Permissions                                 : {8b590330-0eb2-45d0-baca-a00ecf7e7b87, dac1c8fa-e6e4-47b8-a128-599660b8cd5c, 
-    														  f6db0cc3-88cd-4c74-a374-3d8c7cc4c50b}
-    			ClientApplicationIds                        : {4a6c40ea-edc1-4202-8620-dd4060ee6583, 17a961bd-e743-4e6f-8097-d7e6612999a7}
-    			ClientApplicationTenantIds                  : {17a961bd-e743-4e6f-8097-d7e6612999a8, 17a961bd-e743-4e6f-8097-d7e6612999a9, 17a961bd-e743-4e6f-8097-d7e6612999a0}
+    			ResourceApplication                         : 4dddddd4-5ee5-6ff6-7aa7-8bbbbbbbbbb8
+    			Permissions                                 : {1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5, 2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6, 
+    														  3cccccc3-4dd4-5ee5-6ff6-7aaaaaaaaaa7}
+    			ClientApplicationIds                        : {5eeeeee5-6ff6-7aa7-8bb8-9cccccccccc9, 6ffffff6-7aa7-8bb8-9cc9-0dddddddddd0}
+    			ClientApplicationTenantIds                  : {7aaaaaa7-8bb8-9cc9-0dd0-1eeeeeeeeee1, 1aaaaaa1-2bb2-3cc3-4dd4-5eeeeeeeeee5, 2bbbbbb2-3cc3-4dd4-5ee5-6ffffffffff6}
     			ClientApplicationPublisherIds               : {verifiedpublishermpnid}
     			ClientApplicationsFromVerifiedPublisherOnly : True
   description: ""

--- a/azureadps-2.0/AzureAD/New-AzureADMSRoleAssignment.md
+++ b/azureadps-2.0/AzureAD/New-AzureADMSRoleAssignment.md
@@ -24,7 +24,7 @@ The New-AzureADMSRoleAssignment cmdlet creates an Azure Active Directory (Azure 
 
 ### Example 1
 ```powershell
-PS C:\> New-AzureADMSRoleAssignment -RoleDefinitionId 62e90356-69f5-4237-9190-012177145e10 -PrincipalId 69584089-b4d1-4055-9c94-320412efd653 -DirectoryScopeId '/'
+PS C:\> New-AzureADMSRoleAssignment -RoleDefinitionId 62e90356-69f5-4237-9190-012177145e10 -PrincipalId aaaaaaaa-bbbb-cccc-1111-222222222222 -DirectoryScopeId '/'
 ```
 
 This command creates a new role assignment.

--- a/azureadps-2.0/AzureAD/New-AzureADMSRoleAssignment.yml
+++ b/azureadps-2.0/AzureAD/New-AzureADMSRoleAssignment.yml
@@ -14,7 +14,7 @@ syntaxes:
 examples:
 - title: Example 1
   code: |-
-    PS C:\> New-AzureADMSRoleAssignment -RoleDefinitionId 62e90356-69f5-4237-9190-012177145e10 -PrincipalId 69584089-b4d1-4055-9c94-320412efd653 -DirectoryScopeId '/'
+    PS C:\> New-AzureADMSRoleAssignment -RoleDefinitionId 62e90356-69f5-4237-9190-012177145e10 -PrincipalId aaaaaaaa-bbbb-cccc-1111-222222222222 -DirectoryScopeId '/'
   description: |-
     This command creates a new role assignment.
   summary: ""

--- a/azureadps-2.0/AzureAD/Remove-AzureADApplication.md
+++ b/azureadps-2.0/AzureAD/Remove-AzureADApplication.md
@@ -24,7 +24,7 @@ The Remove-AzureADApplication cmdlet removes the specified application from Azur
 
 ### Example 1: Remove an application
 ```
-PS C:\>Remove-AzureADApplication -ObjectId "acd10942-5747-4385-8824-4c5d5fa904f9"
+PS C:\>Remove-AzureADApplication -ObjectId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
 ```
 
 This command removes the specified application.
@@ -103,4 +103,3 @@ See the [migration guide for Remove-AzureADApplication](./migrate/Remove-AzureAD
 [New-AzureADApplication](New-AzureADApplication.md)
 
 [Set-AzureADApplication](Set-AzureADApplication.md)
-

--- a/azureadps-2.0/AzureAD/Remove-AzureADApplication.yml
+++ b/azureadps-2.0/AzureAD/Remove-AzureADApplication.yml
@@ -11,7 +11,7 @@ syntaxes:
 examples:
 - title: 'Example 1: Remove an application'
   code: |-
-    PS C:\>Remove-AzureADApplication -ObjectId "acd10942-5747-4385-8824-4c5d5fa904f9"
+    PS C:\>Remove-AzureADApplication -ObjectId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
   description: |-
     This command removes the specified application.
   summary: ""

--- a/azureadps-2.0/AzureAD/Remove-AzureADApplicationExtensionProperty.md
+++ b/azureadps-2.0/AzureAD/Remove-AzureADApplicationExtensionProperty.md
@@ -24,7 +24,7 @@ The Remove-AzureADApplicationExtensionProperty cmdlet removes an application ext
 
 ### Example 1: Remove an extension property
 ```
-PS C:\> Remove-AzureADApplicationExtensionProperty -ObjectId "3ddd22e7-a150-4bb3-b100-e410dea1cb84" -ExtensionPropertyId "344ed560-f8e7-410e-ab9f-c79df5c36"
+PS C:\> Remove-AzureADApplicationExtensionProperty -ObjectId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -ExtensionPropertyId "344ed560-f8e7-410e-ab9f-c79df5c36"
 ```
 
 This command removes the extension property that has the specified ID from an application in Azure Active Directory.
@@ -116,4 +116,3 @@ See the [migration guide for Remove-AzureADApplicationExtensionProperty](./migra
 [Get-AzureADApplicationExtensionProperty](Get-AzureADApplicationExtensionProperty.md)
 
 [New-AzureADApplicationExtensionProperty](New-AzureADApplicationExtensionProperty.md)
-

--- a/azureadps-2.0/AzureAD/Remove-AzureADApplicationExtensionProperty.yml
+++ b/azureadps-2.0/AzureAD/Remove-AzureADApplicationExtensionProperty.yml
@@ -11,7 +11,7 @@ syntaxes:
 examples:
 - title: 'Example 1: Remove an extension property'
   code: |-
-    PS C:\> Remove-AzureADApplicationExtensionProperty -ObjectId "3ddd22e7-a150-4bb3-b100-e410dea1cb84" -ExtensionPropertyId "344ed560-f8e7-410e-ab9f-c79df5c36"
+    PS C:\> Remove-AzureADApplicationExtensionProperty -ObjectId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -ExtensionPropertyId "344ed560-f8e7-410e-ab9f-c79df5c36"
   description: |-
     This command removes the extension property that has the specified ID from an application in Azure Active Directory.
   summary: ""

--- a/azureadps-2.0/AzureAD/Remove-AzureADApplicationKeyCredential.md
+++ b/azureadps-2.0/AzureAD/Remove-AzureADApplicationKeyCredential.md
@@ -24,7 +24,7 @@ The Remove-AzureADApplicationKeyCredential cmdlet removes a key credential from 
 
 ### Example 1: Remove a key credential
 ```
-PS C:\> Remove-AzureADApplicationKeyCredential -ObjectId "3ddd22e7-a150-4bb3-b100-e410dea1cb84" -KeyId "6aa971c6-3040-45df-87ed-581c8c09ff2b"
+PS C:\> Remove-AzureADApplicationKeyCredential -ObjectId "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb" -KeyId "aaaaaaaa-0b0b-1c1c-2d2d-333333333333"
 ```
 
 This command removes the specified key credential from the specified application.
@@ -114,4 +114,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Get-AzureADApplicationKeyCredential]()
 
 [New-AzureADApplicationKeyCredential]()
-


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/Azure/azure-docs-powershell-azuread/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune
